### PR TITLE
Fixes to load and added a read example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 **/tests/memmap
 libtrx.a
 tests/data
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+**/CMakeCache.txt
+**/CMakeFiles
+**/*.cmake
+**/Makefile
+**/build
+**/bin
+**/load_trx
+**/tests/memmap
+libtrx.a
+tests/data

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_BUILD_TYPE Debug)
 find_package(libzip REQUIRED)
 find_package (Eigen3 CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
+find_package(spdlog CONFIG REQUIRED)
 
 add_library(trx src/trx.cpp src/trx.tpp src/trx.h)
 
@@ -18,6 +19,8 @@ TARGET_LINK_LIBRARIES(trx
 	nlohmann_json::nlohmann_json
 	libzip::zip
 	Eigen3::Eigen
+    spdlog::spdlog
+    spdlog::spdlog_header_only
 )
 
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# TRX-cpp
+
+The C++ implementations to the memory-mapped tractography file format.
+
+## Installation
+### Dependencies
+- c++11 compiler / cmake
+- libzip
+- nlohmann::json
+- Eigen3
+- spdlog
+- GTest (optional)
+
+### Installing
+`cmake . && make`
+
+## How to use
+COMING SOON

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.0.0)
+cmake_policy(SET CMP0074 NEW)
+cmake_policy(SET CMP0079 NEW)
+project(trx)
+set (CMAKE_CXX_STANDARD 11)
+
+set(CMAKE_BUILD_TYPE Debug)
+
+find_package(libzip REQUIRED)
+find_package (Eigen3 CONFIG REQUIRED)
+find_package(nlohmann_json CONFIG REQUIRED)
+
+include_directories(../src)
+add_executable(load_trx load_trx.cpp ../src/trx.h ../src/trx.tpp ../src/trx.cpp)
+
+
+TARGET_LINK_LIBRARIES(load_trx
+	nlohmann_json::nlohmann_json
+	Eigen3::Eigen
+	libzip::zip
+)
+
+
+set(CPACK_PROJECT_NAME ${PROJECT_NAME})
+set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_BUILD_TYPE Debug)
 find_package(libzip REQUIRED)
 find_package (Eigen3 CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
+find_package(spdlog CONFIG REQUIRED)
 
 include_directories(../src)
 add_executable(load_trx load_trx.cpp ../src/trx.h ../src/trx.tpp ../src/trx.cpp)
@@ -18,6 +19,8 @@ TARGET_LINK_LIBRARIES(load_trx
 	nlohmann_json::nlohmann_json
 	Eigen3::Eigen
 	libzip::zip
+	spdlog::spdlog
+	spdlog::spdlog_header_only
 )
 
 

--- a/examples/load_trx.cpp
+++ b/examples/load_trx.cpp
@@ -1,0 +1,33 @@
+#include "../src/trx.h"
+
+using namespace trxmmap;
+int main(int argc, char **argv)
+{
+	trxmmap::TrxFile<half> *trx = trxmmap::load_from_zip<half>(argv[1]);
+
+	std::cout << "Vertices: " << trx->streamlines->_data.size() / 3 << "\n";
+	std::cout << "First vertex (x,y,z): " << trx->streamlines->_data(0, 0)
+		  << "," << trx->streamlines->_data(0, 1)
+		  << "," << trx->streamlines->_data(0, 2) << "\n";
+	std::cout << "Streamlines: " << trx->streamlines->_offsets.size() << "\n";
+	std::cout << "Vertices in first streamline: " << trx->streamlines->_offsets(1) - trx->streamlines->_offsets(0) << "\n";
+	std::cout << "dpg (data_per_group) items: " << trx->data_per_group.size() << "\n";
+	std::cout << "dps (data_per_streamline) items: " << trx->data_per_streamline.size() << "\n";
+
+	for (auto const &x : trx->data_per_streamline)
+	{
+		std::cout << "'" << x.first << "' items: "
+			  << x.second->_matrix.size()
+			  << "\n";
+	}
+
+	std::cout << "dpv (data_per_vertex) items:" << trx->data_per_vertex.size() << "\n";
+	for (auto const &x : trx->data_per_vertex)
+	{
+		std::cout << "'" << x.first << "' items: "
+			  << x.second->_data.size()
+			  << "\n";
+	}
+
+	std::cout << *trx << std::endl;
+}

--- a/src/trx.cpp
+++ b/src/trx.cpp
@@ -10,35 +10,34 @@
 using namespace Eigen;
 using namespace std;
 
-std::string get_base(const std::string &delimiter, const std::string &str)
-{
-	std::string token;
-
-	if (str.rfind(delimiter) + 1 < str.length())
-	{
-		token = str.substr(str.rfind(delimiter) + 1);
-	}
-	else
-	{
-		token = str;
-	}
-	return token;
-}
-
-std::string get_ext(const std::string &str)
-{
-	std::string ext = "";
-	std::string delimeter = ".";
-
-	if (str.rfind(delimeter) + 1 < str.length())
-	{
-		ext = str.substr(str.rfind(delimeter) + 1);
-	}
-	return ext;
-}
-
 namespace trxmmap
 {
+	std::string get_base(const std::string &delimiter, const std::string &str)
+	{
+		std::string token;
+
+		if (str.rfind(delimiter) + 1 < str.length())
+		{
+			token = str.substr(str.rfind(delimiter) + 1);
+		}
+		else
+		{
+			token = str;
+		}
+		return token;
+	}
+
+	std::string get_ext(const std::string &str)
+	{
+		std::string ext = "";
+		std::string delimeter = ".";
+
+		if (str.rfind(delimeter) + 1 < str.length())
+		{
+			ext = str.substr(str.rfind(delimeter) + 1);
+		}
+		return ext;
+	}
 	// TODO: check if there's a better way
 	int _sizeof_dtype(std::string dtype)
 	{
@@ -213,15 +212,17 @@ namespace trxmmap
 			filename.pop_back();
 		}
 
+		long filesize = std::get<0>(shape) * std::get<1>(shape) * _sizeof_dtype(dtype);
 		// if file does not exist, create and allocate it
 		struct stat buffer;
 		if (stat(filename.c_str(), &buffer) != 0)
 		{
-			allocate_file(filename, std::get<0>(shape) * std::get<1>(shape) * _sizeof_dtype(dtype));
+			allocate_file(filename, filesize);
 		}
 
 		// std::error_code error;
-		mio::shared_mmap_sink rw_mmap(filename, offset, mio::map_entire_file);
+
+		mio::shared_mmap_sink rw_mmap(filename, offset, filesize);
 
 		return rw_mmap;
 	}

--- a/src/trx.cpp
+++ b/src/trx.cpp
@@ -276,28 +276,3 @@ namespace trxmmap
 		}
 	}
 };
-// int main(int argc, char *argv[])
-//{
-//  Array<int16_t, 5, 4> arr;
-//  trxmmap::_generate_filename_from_data(arr, "mean_fa.int16");
-
-// // "Test cases" until i create more formal ones
-// int *errorp;
-// char *path = strdup(argv[1]);
-// zip_t *zf = zip_open(path, 0, errorp);
-// Json::Value header = load_header(zf);
-
-// std::cout << "**Reading header**" << std::endl;
-// std::cout << "Dimensions: " << header["DIMENSIONS"] << std::endl;
-// std::cout << "Number of streamlines: " << header["NB_STREAMLINES"] << std::endl;
-// std::cout << "Number of vertices: " << header["NB_VERTICES"] << std::endl;
-// std::cout << "Voxel to RASMM: " << header["VOXEL_TO_RASMM"] << std::endl;
-
-// load_from_zip(path);
-
-// TrxFile trx(1, 1);
-
-// std::cout << "Printing trk streamline data value " << trx.streamlines._data(0, 0) << endl;
-// std::cout << "Printing trk streamline offset value " << trx.streamlines._offset(0, 0) << endl;
-// return 1;
-//}

--- a/src/trx.h
+++ b/src/trx.h
@@ -27,7 +27,7 @@ namespace trxmmap
 	template <typename DT>
 	struct ArraySequence
 	{
-		Map<Matrix<DT, Dynamic, Dynamic>> _data;
+		Map<Matrix<DT, Dynamic, Dynamic, RowMajor>> _data;
 		Map<Matrix<uint64_t, Dynamic, Dynamic, RowMajor>> _offsets;
 		Matrix<uint32_t, Dynamic, 1> _lengths;
 		mio::shared_mmap_sink mmap_pos;
@@ -77,6 +77,13 @@ namespace trxmmap
 		 * @return TrxFile*
 		 */
 		static TrxFile<DT> *_create_trx_from_pointer(json header, std::map<std::string, std::tuple<long long, long long>> dict_pointer_size, std::string root_zip = "", std::string root = "");
+
+		/**
+		 * @brief Create a deepcopy of the TrxFile
+		 *
+		 * @return TrxFile<DT>* A deepcopied TrxFile of the current object
+		 */
+		TrxFile<DT> *deepcopy();
 
 	private:
 		int len();
@@ -158,7 +165,7 @@ namespace trxmmap
 	void get_reference_info(std::string reference, const MatrixXf &affine, const RowVectorXf &dimensions);
 
 	template <typename DT>
-	std::ostream &operator<<(std::ostream &out, const TrxFile<DT> &TrxFile);
+	std::ostream &operator<<(std::ostream &out, const TrxFile<DT> &trx);
 	// private:
 
 	void allocate_file(const std::string &path, const int size);
@@ -218,6 +225,20 @@ namespace trxmmap
 
 	template <typename DT>
 	void ediff1d(Matrix<DT, Dynamic, 1> &lengths, const Matrix<DT, Dynamic, Dynamic> &tmp, uint32_t to_end);
+
+	/**
+	 * @brief Save a TrxFile
+	 *
+	 * @tparam DT
+	 * @param trx The TrxFile to save
+	 * @param filename  The path to save the TrxFile to
+	 * @param compression_standard The compression standard to use, as defined by libzip (default: no compression)
+	 */
+	template <typename DT>
+	void save(MatrixBase<DT> &trx, std::string filename, zip_uint32_t compression_standard = ZIP_CM_STORE);
+
+	std::string get_base(const std::string &delimiter, const std::string &str);
+	std::string get_ext(const std::string &str);
 #include "trx.tpp"
 
 }

--- a/src/trx.h
+++ b/src/trx.h
@@ -89,7 +89,39 @@ namespace trxmmap
 		 */
 		TrxFile<DT> *deepcopy();
 
+		/**
+		 * @brief Remove the ununsed portion of preallocated memmaps
+		 *
+		 * @param nb_streamlines The number of streamlines to keep
+		 * @param nb_vertices The number of vertices to keep
+		 * @param delete_dpg Remove data_per_group when resizing
+		 */
+		void resize(int nb_streamlines = -1, int nb_vertices = -1, bool delete_dpg = false);
+
+		/**
+		 * @brief Cleanup on-disk temporary folder and initialize an empty TrxFile
+		 *
+		 */
+		void close();
+
 	private:
+		/**
+		 * @brief Get the real size of data (ignoring zeros of preallocation)
+		 *
+		 * @return std::tuple<int, int> A tuple representing the index of the last streamline and the total length of all the streamlines
+		 */
+		std::tuple<int, int> _get_real_len();
+
+		/**
+		 * @brief Fill a TrxFile using another and start indexes (preallocation)
+		 *
+		 * @param trx TrxFile to copy data from
+		 * @param strs_start The start index of the streamline
+		 * @param pts_start The start index of the point
+		 * @param nb_strs_to_copy The number of streamlines to copy. If not set will copy all
+		 * @return std::tuple<int, int> A tuple representing the end of the copied streamlines and end of copied points
+		 */
+		std::tuple<int, int> _copy_fixed_arrays_from(TrxFile<DT> *trx, int strs_start = 0, int pts_start = 0, int nb_strs_to_copy = -1);
 		int len();
 	};
 

--- a/src/trx.h
+++ b/src/trx.h
@@ -16,6 +16,8 @@
 #include <mio/mmap.hpp>
 #include <mio/shared_mmap.hpp>
 
+#include "spdlog/spdlog.h"
+
 using namespace Eigen;
 using json = nlohmann::json;
 

--- a/src/trx.h
+++ b/src/trx.h
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <zip.h>
 #include <string.h>
+#include <dirent.h>
 #include <nlohmann/json.hpp>
 #include <algorithm>
 #include <variant>
@@ -24,6 +25,7 @@ using json = nlohmann::json;
 namespace trxmmap
 {
 
+	const std::string SEPARATOR = "/";
 	const std::vector<std::string> dtypes({"float16", "bit", "uint8", "uint16", "uint32", "uint64", "int8", "int16", "int32", "int64", "float32", "float64"});
 
 	template <typename DT>
@@ -144,7 +146,7 @@ namespace trxmmap
 	 *
 	 * */
 	template <typename DT>
-	TrxFile<DT> *load_from_zip(std::string *path);
+	TrxFile<DT> *load_from_zip(std::string path);
 
 	/**
 	 * @brief Load a TrxFile from a folder containing memmaps
@@ -154,7 +156,7 @@ namespace trxmmap
 	 * @return TrxFile<DT>* TrxFile representing the read data
 	 */
 	template <typename DT>
-	TrxFile<DT> *load_from_directory(std::string *path);
+	TrxFile<DT> *load_from_directory(std::string path);
 
 	/**
 	 * Get affine and dimensions from a Nifti or Trk file (Adapted from dipy)
@@ -188,7 +190,7 @@ namespace trxmmap
 	mio::shared_mmap_sink _create_memmap(std::string &filename, std::tuple<int, int> &shape, std::string mode = "r", std::string dtype = "float32", long long offset = 0);
 
 	template <typename DT>
-	std::string _generate_filename_from_data(const ArrayBase<DT> &arr, const std::string filename);
+	std::string _generate_filename_from_data(const MatrixBase<DT> &arr, const std::string filename);
 	std::tuple<std::string, int, std::string> _split_ext_with_dimensionality(const std::string filename);
 
 	/**
@@ -241,6 +243,7 @@ namespace trxmmap
 
 	std::string get_base(const std::string &delimiter, const std::string &str);
 	std::string get_ext(const std::string &str);
+	void populate_fps(const char *name, std::map<std::string, std::tuple<long long, long long>> &file_pointer_size);
 #include "trx.tpp"
 
 }

--- a/src/trx.h
+++ b/src/trx.h
@@ -138,6 +138,16 @@ namespace trxmmap
 	TrxFile<DT> *load_from_zip(std::string *path);
 
 	/**
+	 * @brief Load a TrxFile from a folder containing memmaps
+	 *
+	 * @tparam DT
+	 * @param path path of the zipped TrxFile
+	 * @return TrxFile<DT>* TrxFile representing the read data
+	 */
+	template <typename DT>
+	TrxFile<DT> *load_from_directory(std::string *path);
+
+	/**
 	 * Get affine and dimensions from a Nifti or Trk file (Adapted from dipy)
 	 *
 	 * @param[in] reference a string pointing to a NIfTI or trk file to be used as reference

--- a/src/trx.h
+++ b/src/trx.h
@@ -271,11 +271,26 @@ namespace trxmmap
 	 * @param compression_standard The compression standard to use, as defined by libzip (default: no compression)
 	 */
 	template <typename DT>
-	void save(MatrixBase<DT> &trx, std::string filename, zip_uint32_t compression_standard = ZIP_CM_STORE);
+	void save(TrxFile<DT> &trx, const std::string filename, zip_uint32_t compression_standard = ZIP_CM_STORE);
+
+	/**
+	 * @brief Utils function to zip on-disk memmaps
+	 *
+	 * @param directory The path to the on-disk memmap
+	 * @param filename The path where the zip file should be created
+	 * @param compression_standard The compression standard to use, as defined by the ZipFile library
+	 */
+	void zip_from_folder(zip_t *zf, const std::string root, const std::string directory, zip_uint32_t compression_standard = ZIP_CM_STORE);
 
 	std::string get_base(const std::string &delimiter, const std::string &str);
 	std::string get_ext(const std::string &str);
 	void populate_fps(const char *name, std::map<std::string, std::tuple<long long, long long>> &file_pointer_size);
+
+	void copy_dir(const char *src, const char *dst);
+	void copy_file(const char *src, const char *dst);
+	int rm_dir(const char *d);
+
+	std::string rm_root(std::string root, const std::string path);
 #include "trx.tpp"
 
 }

--- a/src/trx.tpp
+++ b/src/trx.tpp
@@ -268,14 +268,13 @@ TrxFile<DT> *_initialize_empty_trx(int nb_streamlines, int nb_vertices, const Tr
 
 	std::string offsets_filename(tmp_dir);
 	offsets_filename += "/offsets." + offsets_dtype;
-	std::cout << "filesystem path " << offsets_filename << std::endl;
 
 	std::tuple<int, int> shape_off = std::make_tuple(nb_streamlines, 1);
 
 	trx->streamlines->mmap_off = trxmmap::_create_memmap(offsets_filename, shape_off, "w+", offsets_dtype);
-	new (&(trx->streamlines->_offsets)) Map<Matrix<uint64_t, 1, Dynamic, RowMajor>>(reinterpret_cast<uint64_t *>(trx->streamlines->mmap_off.data()), std::get<0>(shape_off), std::get<1>(shape_off));
+	new (&(trx->streamlines->_offsets)) Map<Matrix<uint64_t, Dynamic, 1>>(reinterpret_cast<uint64_t *>(trx->streamlines->mmap_off.data()), std::get<0>(shape_off), std::get<1>(shape_off));
 
-	trx->streamlines->_lengths.resize(nb_streamlines, 0);
+	trx->streamlines->_lengths.resize(nb_streamlines, 1);
 
 	if (init_as != NULL)
 	{
@@ -678,8 +677,14 @@ TrxFile<DT> *load_from_zip(std::string filename)
 			global_pos += sb.comp_size + elem_filename.size();
 		}
 
-		long long size = sb.comp_size / _sizeof_dtype(ext);
+		long long size = sb.size / _sizeof_dtype(ext);
 		file_pointer_size[elem_filename] = {mem_address, size};
 	}
 	return TrxFile<DT>::_create_trx_from_pointer(header, file_pointer_size, filename);
 }
+
+// TrxFile<DT> *load_from_directory(std::string *path)
+// {
+// 	std::string directory = string(canonicalize_file_name(path->c_str()));
+// 	std::string header = directory
+// }

--- a/src/trx.tpp
+++ b/src/trx.tpp
@@ -28,7 +28,7 @@ std::string _generate_filename_from_data(const ArrayBase<DT> &arr, std::string f
 
 	if (ext.size() != 0)
 	{
-		std::cout << "WARNING: Will overwrite provided extension if needed." << std::endl;
+		spdlog::warn("Will overwrite provided extension if needed.");
 	}
 
 	std::string eigen_dt = typeid(arr.matrix().data()).name();
@@ -141,8 +141,7 @@ TrxFile<DT>::TrxFile(int nb_vertices, int nb_streamlines, const TrxFile<DT> *ini
 	// TODO: add else if for get_reference_info
 	else
 	{
-		// TODO: logger
-		std::cout << "No reference provided, using blank space attributes, please update them later." << std::endl;
+		spdlog::debug("No reference provided, using blank space attributes, please update them later.");
 
 		// identity matrix
 		for (int i = 0; i < 4; i++)
@@ -161,8 +160,7 @@ TrxFile<DT>::TrxFile(int nb_vertices, int nb_streamlines, const TrxFile<DT> *ini
 			throw std::invalid_argument("Can't us init_as without declaring nb_vertices and nb_streamlines");
 		}
 
-		// TODO: logger
-		std::cout << "Initializing empty TrxFile." << std::endl;
+		spdlog::debug("Initializing empty TrxFile.");
 		// will remove as completely unecessary. using as placeholders
 		this->header = {};
 
@@ -177,8 +175,7 @@ TrxFile<DT>::TrxFile(int nb_vertices, int nb_streamlines, const TrxFile<DT> *ini
 	}
 	else if (nb_vertices > 0 && nb_streamlines > 0)
 	{
-		// TODO: logger
-		std::cout << "Preallocating TrxFile with size " << nb_streamlines << " streamlines and " << nb_vertices << " vertices." << std::endl;
+		spdlog::debug("Preallocating TrxFile with size {} streamlines and {} vertices.", nb_streamlines, nb_vertices);
 		TrxFile<DT> *trx = _initialize_empty_trx<DT>(nb_streamlines, nb_vertices, init_as);
 		this->streamlines = trx->streamlines;
 		this->groups = trx->groups;
@@ -212,7 +209,7 @@ TrxFile<DT> *_initialize_empty_trx(int nb_streamlines, int nb_vertices, const Tr
 
 	std::string tmp_dir(dirname);
 
-	std::cout << "Temporary folder for memmaps: " << tmp_dir << std::endl;
+	spdlog::info("Temporary folder for memmaps: {}", tmp_dir);
 
 	trx->header["NB_VERTICES"] = nb_vertices;
 	trx->header["NB_STREAMLINES"] = nb_streamlines;
@@ -235,13 +232,9 @@ TrxFile<DT> *_initialize_empty_trx(int nb_streamlines, int nb_vertices, const Tr
 		offsets_dtype = _get_dtype(typeid(uint64_t).name());
 		lengths_dtype = _get_dtype(typeid(uint32_t).name());
 	}
-
-	std::cout << "Initializing positions with dtype: "
-		  << positions_dtype << std::endl;
-	std::cout << "Initializing offsets with dtype: "
-		  << offsets_dtype << std::endl;
-	std::cout << "Initializing lengths with dtype: "
-		  << lengths_dtype << std::endl;
+	spdlog::debug("Initializing positions with dtype: {}", positions_dtype);
+	spdlog::debug("Initializing offsets with dtype: {}", offsets_dtype);
+	spdlog::debug("Initializing lengths with dtype: {}", lengths_dtype);
 
 	std::string positions_filename(tmp_dir);
 	positions_filename += "/positions.3." + positions_dtype;
@@ -312,9 +305,7 @@ TrxFile<DT> *_initialize_empty_trx(int nb_streamlines, int nb_vertices, const Tr
 				dpv_filename = dpv_dirname + x.first + "." + std::to_string(cols) + "." + dpv_dtype;
 			}
 
-			// TODO: logger
-			std::cout << "Initializing " << x.first << " (dpv) with dtype: "
-				  << dpv_dtype << std::endl;
+			spdlog::debug("Initializing {} (dpv) with dtype: {}", x.first, dpv_dtype);
 
 			std::tuple<int, int> dpv_shape = std::make_tuple(rows, cols);
 			trx->data_per_vertex[x.first] = new ArraySequence<DT>();
@@ -357,8 +348,7 @@ TrxFile<DT> *_initialize_empty_trx(int nb_streamlines, int nb_vertices, const Tr
 				dps_filename = dps_dirname + x.first + "." + std::to_string(cols) + "." + dps_dtype;
 			}
 
-			// TODO: logger
-			std::cout << "Initializing " << x.first << " (dps) with and dtype: " << dps_dtype << std::endl;
+			spdlog::debug("Initializing {} (dps) with dtype: {}", x.first, dps_dtype);
 
 			std::tuple<int, int> dps_shape = std::make_tuple(rows, cols);
 			trx->data_per_streamline[x.first] = new trxmmap::MMappedMatrix<DT>();
@@ -548,7 +538,7 @@ TrxFile<DT> *TrxFile<DT>::_create_trx_from_pointer(json header, std::map<std::st
 			trx->data_per_vertex[base]->_lengths = trx->streamlines->_lengths;
 		}
 
-		else if (folder.compare("dpg") == 0)
+		else if (folder.rfind("dpg", 0) == 0)
 		{
 			std::tuple<int, int> shape;
 			trx->data_per_streamline[base] = new MMappedMatrix<DT>();
@@ -600,8 +590,7 @@ TrxFile<DT> *TrxFile<DT>::_create_trx_from_pointer(json header, std::map<std::st
 		}
 		else
 		{
-			// TODO: logger
-			std::cout << elem_filename << " is not part of a valid structure." << std::endl;
+			spdlog::error("{} is not part of a valid structure.", elem_filename);
 		}
 	}
 	if (trx->streamlines->_data.size() == 0 || trx->streamlines->_offsets.size() == 0)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_BUILD_TYPE Debug)
 find_package(libzip REQUIRED)
 find_package (Eigen3 CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
+find_package(spdlog CONFIG REQUIRED)
 find_package(GTest CONFIG REQUIRED)
 
 enable_testing()
@@ -28,6 +29,8 @@ TARGET_LINK_LIBRARIES(test_mmap
 	libzip::zip
 	GTest::gtest
 	GTest::gtest_main
+	spdlog::spdlog
+	spdlog::spdlog_header_only
 )
 
 

--- a/tests/test_trx_mmap.cpp
+++ b/tests/test_trx_mmap.cpp
@@ -305,6 +305,13 @@ TEST(TrxFileMemmap, deepcopy)
 	EXPECT_EQ(trx->streamlines->_lengths, trx->streamlines->_lengths);
 }
 
+TEST(TrxFileMemmap, resize)
+{
+	trxmmap::TrxFile<half> *trx = trxmmap::load_from_zip<half>("data/small.trx");
+	trx->resize();
+	trx->resize(10);
+}
+
 int main(int argc, char **argv)
 {
 	::testing::InitGoogleTest(&argc, argv);

--- a/tests/test_trx_mmap.cpp
+++ b/tests/test_trx_mmap.cpp
@@ -311,6 +311,15 @@ TEST(TrxFileMemmap, resize)
 	trx->resize();
 	trx->resize(10);
 }
+TEST(TrxFileMemmap, save)
+{
+	trxmmap::TrxFile<half> *trx = trxmmap::load_from_zip<half>("data/small.trx");
+	trxmmap::save(*trx, (std::string) "testsave");
+	trxmmap::save(*trx, (std::string) "testsave.trx");
+
+	// trxmmap::TrxFile<half> *saved = trxmmap::load_from_zip<half>("testsave.trx");
+	//  EXPECT_EQ(saved->data_per_vertex["color_x.float16"]->_data, trx->data_per_vertex["color_x.float16"]->_data);
+}
 
 int main(int argc, char **argv)
 {

--- a/tests/test_trx_mmap.cpp
+++ b/tests/test_trx_mmap.cpp
@@ -12,21 +12,21 @@ TEST(TrxFileMemmap, __generate_filename_from_data)
 	std::string filename = "mean_fa.bit";
 	std::string output_fn;
 
-	Array<int16_t, 5, 4> arr1;
+	Matrix<int16_t, 5, 4> arr1;
 	std::string exp_1 = "mean_fa.4.int16";
 
 	output_fn = _generate_filename_from_data(arr1, filename);
 	EXPECT_STREQ(output_fn.c_str(), exp_1.c_str());
 	output_fn.clear();
 
-	Array<double, 5, 4> arr2;
+	Matrix<double, 5, 4> arr2;
 	std::string exp_2 = "mean_fa.4.float64";
 
 	output_fn = _generate_filename_from_data(arr2, filename);
 	EXPECT_STREQ(output_fn.c_str(), exp_2.c_str());
 	output_fn.clear();
 
-	Array<double, 5, 1> arr3;
+	Matrix<double, 5, 1> arr3;
 	std::string exp_3 = "mean_fa.float64";
 
 	output_fn = _generate_filename_from_data(arr3, filename);
@@ -297,7 +297,12 @@ TEST(TrxFileMemmap, TrxFile)
 TEST(TrxFileMemmap, deepcopy)
 {
 	trxmmap::TrxFile<half> *trx = trxmmap::load_from_zip<half>("data/small.trx");
-	// trx->deepcopy();
+	trxmmap::TrxFile<half> *copy = trx->deepcopy();
+
+	EXPECT_EQ(trx->header, copy->header);
+	EXPECT_EQ(trx->streamlines->_data, trx->streamlines->_data);
+	EXPECT_EQ(trx->streamlines->_offsets, trx->streamlines->_offsets);
+	EXPECT_EQ(trx->streamlines->_lengths, trx->streamlines->_lengths);
 }
 
 int main(int argc, char **argv)

--- a/tests/test_trx_mmap.cpp
+++ b/tests/test_trx_mmap.cpp
@@ -204,7 +204,7 @@ TEST(TrxFileMemmap, __create_memmap)
 
 TEST(TrxFileMemmap, load_header)
 {
-	std::string path = "../../tests/data/small.trx";
+	std::string path = "data/small.trx";
 	int *errorp;
 	zip_t *zf = zip_open(path.c_str(), 0, errorp);
 	json root = trxmmap::load_header(zf);
@@ -247,51 +247,51 @@ TEST(TrxFileMemmap, load_header)
 
 TEST(TrxFileMemmap, load_zip)
 {
-	trxmmap::TrxFile<half> *trx = trxmmap::load_from_zip<half>("../../tests/data/small.trx");
+	trxmmap::TrxFile<half> *trx = trxmmap::load_from_zip<half>("data/small.trx");
 	EXPECT_GT(trx->streamlines->_data.size(), 0);
 }
 
 TEST(TrxFileMemmap, TrxFile)
 {
-	// trxmmap::TrxFile<half> *trx = new TrxFile<half>();
+	trxmmap::TrxFile<half> *trx = new TrxFile<half>();
 
-	// // expected header
-	// json expected;
+	// expected header
+	json expected;
 
-	// expected["DIMENSIONS"] = {1, 1, 1};
-	// expected["NB_STREAMLINES"] = 0;
-	// expected["NB_VERTICES"] = 0;
-	// expected["VOXEL_TO_RASMM"] = {{1.0, 0.0, 0.0, 0.0},
-	// 			      {0.0, 1.0, 0.0, 0.0},
-	// 			      {0.0, 0.0, 1.0, 0.0},
-	// 			      {0.0, 0.0, 0.0, 1.0}};
+	expected["DIMENSIONS"] = {1, 1, 1};
+	expected["NB_STREAMLINES"] = 0;
+	expected["NB_VERTICES"] = 0;
+	expected["VOXEL_TO_RASMM"] = {{1.0, 0.0, 0.0, 0.0},
+				      {0.0, 1.0, 0.0, 0.0},
+				      {0.0, 0.0, 1.0, 0.0},
+				      {0.0, 0.0, 0.0, 1.0}};
 
-	// EXPECT_EQ(trx->header, expected);
+	EXPECT_EQ(trx->header, expected);
 
-	// std::string path = "../../tests/data/small.trx";
-	// int *errorp;
-	// zip_t *zf = zip_open(path.c_str(), 0, errorp);
-	// json root = trxmmap::load_header(zf);
-	// TrxFile<half> *root_init = new TrxFile<half>();
-	// root_init->header = root;
+	std::string path = "data/small.trx";
+	int *errorp;
+	zip_t *zf = zip_open(path.c_str(), 0, errorp);
+	json root = trxmmap::load_header(zf);
+	TrxFile<half> *root_init = new TrxFile<half>();
+	root_init->header = root;
 
-	// // TODO: test for now..
+	// TODO: test for now..
 
-	// trxmmap::TrxFile<half> *trx_init = new TrxFile<half>(33886, 1000, root_init);
-	// json init_as;
+	trxmmap::TrxFile<half> *trx_init = new TrxFile<half>(33886, 1000, root_init);
+	json init_as;
 
-	// init_as["DIMENSIONS"] = {117, 151, 115};
-	// init_as["NB_STREAMLINES"] = 1000;
-	// init_as["NB_VERTICES"] = 33886;
-	// init_as["VOXEL_TO_RASMM"] = {{-1.25, 0.0, 0.0, 72.5},
-	// 			     {0.0, 1.25, 0.0, -109.75},
-	// 			     {0.0, 0.0, 1.25, -64.5},
-	// 			     {0.0, 0.0, 0.0, 1.0}};
+	init_as["DIMENSIONS"] = {117, 151, 115};
+	init_as["NB_STREAMLINES"] = 1000;
+	init_as["NB_VERTICES"] = 33886;
+	init_as["VOXEL_TO_RASMM"] = {{-1.25, 0.0, 0.0, 72.5},
+				     {0.0, 1.25, 0.0, -109.75},
+				     {0.0, 0.0, 1.25, -64.5},
+				     {0.0, 0.0, 0.0, 1.0}};
 
-	// EXPECT_EQ(root_init->header, init_as);
-	// EXPECT_EQ(trx_init->streamlines->_data.size(), 33886 * 3);
-	// EXPECT_EQ(trx_init->streamlines->_offsets.size(), 1000);
-	// EXPECT_EQ(trx_init->streamlines->_lengths.size(), 1000);
+	EXPECT_EQ(root_init->header, init_as);
+	EXPECT_EQ(trx_init->streamlines->_data.size(), 33886 * 3);
+	EXPECT_EQ(trx_init->streamlines->_offsets.size(), 1000);
+	EXPECT_EQ(trx_init->streamlines->_lengths.size(), 1000);
 }
 
 int main(int argc, char **argv)

--- a/tests/test_trx_mmap.cpp
+++ b/tests/test_trx_mmap.cpp
@@ -294,6 +294,12 @@ TEST(TrxFileMemmap, TrxFile)
 	EXPECT_EQ(trx_init->streamlines->_lengths.size(), 1000);
 }
 
+TEST(TrxFileMemmap, deepcopy)
+{
+	trxmmap::TrxFile<half> *trx = trxmmap::load_from_zip<half>("data/small.trx");
+	// trx->deepcopy();
+}
+
 int main(int argc, char **argv)
 {
 	::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Fixed bug w/ loading (reading zip data at incorrect offsets)
Addresses issue #2 : added an example in `examples/load_trx.cpp`.
~Currently still prints some undesirable logging output, which will be fixed soon.~

Current example run:
```
./load_trx ../tests/data/small.trx 
Vertices: 33886
First vertex (x,y,z): 20.2812,-33.4375,-41.9062
Streamlines: 1000
Vertices in first streamline: 31
dpg (data_per_group) items: 0
dps (data_per_streamline) items: 4
'algo' items: 1000
'clusters_QB' items: 1000
'commit_colors' items: 3000
'commit_weights' items: 1000
dpv (data_per_vertex) items:4
'color_x' items: 33886
'color_y' items: 33886
'color_z' items: 33886
'fa' items: 33886
Header (header.json):
{
    "DIMENSIONS": [
        117,
        151,
        115
    ],
    "NB_STREAMLINES": 1000,
    "NB_VERTICES": 33886,
    "VOXEL_TO_RASMM": [
        [
            -1.25,
            0.0,
            0.0,
            72.5
        ],
        [
            0.0,
            1.25,
            0.0,
            -109.75
        ],
        [
            0.0,
            0.0,
            1.25,
            -64.5
        ],
        [
            0.0,
            0.0,
            0.0,
            1.0
        ]
    ]
}
```
Marking it as draft for now, but if you'd prefer to merge it as is, that works too.