### PR TITLE
Updated README.md and updated required packages to include mio

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,31 @@
 The C++ implementations to the memory-mapped tractography file format.
 
 ## Installation
+
 ### Dependencies
+
 - c++11 compiler / cmake
 - libzip
 - nlohmann::json
 - Eigen3
 - spdlog
 - GTest (optional)
+- mio
 
 ### Installing
+
 `cmake . && make`
 
 ## How to use
-COMING SOON
+
+* Install all dependencies (after either cloning github repo or downloading) using these commands
+  * `mkdir build`
+  * `cd build`
+  * `cmake ..`
+  * `make`
+  * `make install`
+* clone into this repo using `git clone https://github.com/tee-ar-ex/trx-cpp.git`
+* To run trx_cpp:
+  * `cmake -B build`
+  * `cd build`
+  * `make`

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package (Eigen3 CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(spdlog CONFIG REQUIRED)
 find_package(GTest CONFIG REQUIRED)
+find_package(mio REQUIRED)
 
 enable_testing()
 


### PR DESCRIPTION
- Added further instructions on installing dependencies and building trx-cpp. 
- Added mio to required packages in tests/CMakeLists.txt

To do: 

- [ ] As discussed we are going to stick with C++ 11 as our anciptaed user uses MRtrix3(https://www.mrtrix.org/) that uses C++ 11. So, we need to use the appropriate google test framework that supports C++ 11. 
- [ ] Currently facing this error while building trx-cpp - "error: use of undeclared identifier 'canonicalize_file_name" orginating from src/trx.tpp line 1097. Tried including stdlib.h in header file but that did not resolve this error. 
