### PR TITLE
FIX handle temp files on mac

### DIFF
--- a/include/trx/trx.h
+++ b/include/trx/trx.h
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <zip.h>
 #include <string.h>
+#include <vector>
 #include <dirent.h>
 #include <nlohmann/json.hpp>
 #include <algorithm>
@@ -40,6 +41,7 @@ namespace trxmmap
 		Map<Matrix<DT, Dynamic, Dynamic, RowMajor>> _data;
 		Map<Matrix<uint64_t, Dynamic, Dynamic, RowMajor>> _offsets;
 		Matrix<uint32_t, Dynamic, 1> _lengths;
+		std::vector<uint64_t> _offsets_owned;
 		mio::shared_mmap_sink mmap_pos;
 		mio::shared_mmap_sink mmap_off;
 

--- a/src/trx.cpp
+++ b/src/trx.cpp
@@ -24,6 +24,10 @@ namespace trxmmap
 
 		while ((entry = readdir(dir)) != NULL)
 		{
+			if (entry->d_name[0] == '.')
+				continue;
+			if (strcmp(entry->d_name, "__MACOSX") == 0)
+				continue;
 			if (entry->d_type == DT_DIR)
 			{
 				char path[1024];


### PR DESCRIPTION
If someone opens a trx directory in Finder on Mac OS a temp file (.DS_Store) gets created, which causes a bus error. This should fix that.

Also handles offsets.uint32 by upcasting into owned storage; uses _offsets.data() for dpv offsets.
Adds owned offsets buffer to trx-cpp/include/trx/trx.h