### PR TITLE
Vendor json11 for json read/write

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,4 @@ delete trx;
 `TrxFile` uses memory-mapped arrays under the hood for large datasets. The
 `close()` method cleans up any temporary folders created during zip extraction.
 If you skip `close()`, temporary directories may be left behind.
+


### PR DESCRIPTION
The json files used by the TRX format are small and simple. This PR replaces the dependency on nlohmann_json with json11.