### PR TITLE
Remove dependency on spdlog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ if (NOT TARGET Eigen3::Eigen AND EXISTS "${EIGEN3_INCLUDE_DIR}")
         INTERFACE_INCLUDE_DIRECTORIES "${EIGEN3_INCLUDE_DIR}"
     )
 endif()
-find_package(spdlog CONFIG REQUIRED)
 set(TRX_HAVE_MIO_TARGET OFF)
 set(MIO_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/mio/include")
 if (NOT EXISTS "${MIO_INCLUDE_DIR}/mio/mmap.hpp")
@@ -76,7 +75,6 @@ TARGET_LINK_LIBRARIES(trx
     PUBLIC
         ${TRX_LIBZIP_TARGET}
         Eigen3::Eigen
-        spdlog::spdlog
         $<$<BOOL:${TRX_HAVE_MIO_TARGET}>:mio::mio>
 )
 target_include_directories(trx

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Required:
 - C++11 compiler and CMake (>= 3.10)
 - libzip
 - Eigen3
-- spdlog
 
 Optional:
 - GTest (for building tests)

--- a/cmake/trx-cppConfig.cmake.in
+++ b/cmake/trx-cppConfig.cmake.in
@@ -3,7 +3,6 @@
 include(CMakeFindDependencyMacro)
 find_dependency(libzip)
 find_dependency(Eigen3)
-find_dependency(spdlog)
 # mio is header-only; try to locate if packaged
 find_dependency(mio QUIET)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -41,7 +41,6 @@ class TrxCppConan(ConanFile):
     def requirements(self):
         self.requires("libzip/1.10.1")
         self.requires("eigen/3.4.0")
-        self.requires("spdlog/1.12.0")
 
     def build_requirements(self):
         if self.options.with_tests:
@@ -84,14 +83,6 @@ class TrxCppConan(ConanFile):
         mio_include = os.path.join(self.source_folder, "third_party", "mio", "include")
         copy(self, "mio/*", src=mio_include, dst=os.path.join(self.package_folder, "include"))
 
-        spdlog_dep = self.dependencies.get("spdlog")
-        if spdlog_dep and spdlog_dep.package_folder:
-            spdlog_include = os.path.join(spdlog_dep.package_folder, "include")
-            copy(self, "spdlog/*", src=spdlog_include, dst=os.path.join(self.package_folder, "include"))
-        fmt_dep = self.dependencies.get("fmt")
-        if fmt_dep and fmt_dep.package_folder:
-            fmt_include = os.path.join(fmt_dep.package_folder, "include")
-            copy(self, "fmt/*", src=fmt_include, dst=os.path.join(self.package_folder, "include"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "trx-cpp")
@@ -102,7 +93,6 @@ class TrxCppConan(ConanFile):
         self.cpp_info.components["trx"].libs = ["trx"]
         self.cpp_info.components["trx"].requires = [
             "libzip::libzip",
-            "spdlog::spdlog",
             "eigen::Eigen3::Eigen",
         ]
         extra_includes = []

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,7 +8,6 @@ set(CMAKE_BUILD_TYPE Debug)
 
 find_package(libzip REQUIRED)
 find_package (Eigen3 CONFIG REQUIRED)
-find_package(spdlog CONFIG REQUIRED)
 
 include_directories(../src)
 include_directories(../third_party/json11)
@@ -24,8 +23,6 @@ add_executable(load_trx
 TARGET_LINK_LIBRARIES(load_trx
 	Eigen3::Eigen
 	libzip::zip
-	spdlog::spdlog
-	spdlog::spdlog_header_only
 )
 
 

--- a/include/trx/trx.h
+++ b/include/trx/trx.h
@@ -21,11 +21,6 @@
 #include <mio/mmap.hpp>
 #include <mio/shared_mmap.hpp>
 
-#ifndef SPDLOG_FMT_EXTERNAL
-#define SPDLOG_FMT_EXTERNAL
-#endif
-#include "spdlog/spdlog.h"
-
 using namespace Eigen;
 using json = json11::Json;
 

--- a/src/trx.cpp
+++ b/src/trx.cpp
@@ -386,7 +386,7 @@ mio::shared_mmap_sink _create_memmap(std::string filename, std::tuple<int, int> 
 
 		if (mkdir(dst, S_IRWXU) != 0)
 		{
-			spdlog::error("Could not create directory {}", dst);
+		throw std::runtime_error(std::string("Could not create directory ") + dst);
 		}
 
 		while ((entry = readdir(dir)) != NULL)
@@ -470,7 +470,6 @@ mio::shared_mmap_sink _create_memmap(std::string filename, std::tuple<int, int> 
 				snprintf(fn, sizeof(fn), "%s%s%s", d, SEPARATOR.c_str(), entry->d_name);
 				if (remove(fn) != 0)
 				{
-					spdlog::error("Could not remove file {}", fn);
 					return -1;
 				}
 			}
@@ -694,11 +693,11 @@ mio::shared_mmap_sink _create_memmap(std::string filename, std::tuple<int, int> 
 				    (file_idx = zip_file_add(zf, fn.c_str(), s, ZIP_FL_ENC_UTF_8)) < 0)
 				{
 					zip_source_free(s);
-					spdlog::error("error adding file {}: {}", fn, zip_strerror(zf));
+					throw std::runtime_error(std::string("Error adding file ") + fn + ": " + zip_strerror(zf));
 				}
 				else if (zip_set_file_compression(zf, file_idx, compression_standard, 0) < 0)
 				{
-					spdlog::error("error setting compression for {}: {}", fn, zip_strerror(zf));
+					throw std::runtime_error(std::string("Error setting compression for ") + fn + ": " + zip_strerror(zf));
 				}
 			}
 		}


### PR DESCRIPTION
This removes the spdlog dependency by

 1. Making critical log messages into exceptions
 2. Moving warnings to comments in the functions. These should go into documentation in a followup PR