### PR TITLE
Positions substring bug

### DIFF
--- a/include/trx/trx.tpp
+++ b/include/trx/trx.tpp
@@ -359,7 +359,7 @@ TrxFile<DT>::_create_trx_from_pointer(json header,
 
       std::tuple<int, int> shape = std::make_tuple(static_cast<int>(trx->header["NB_VERTICES"].int_value()), 3);
       trx->streamlines->mmap_pos =
-          trx::_create_memmap(filename, shape, "r+", ext.substr(1, ext.size() - 1), mem_adress);
+          trx::_create_memmap(filename, shape, "r+", ext, mem_adress);
 
       trx::detail::remap(trx->streamlines->_data, trx->streamlines->mmap_pos.data(), shape);
     }

--- a/src/detail/dtype_helpers.cpp
+++ b/src/detail/dtype_helpers.cpp
@@ -27,7 +27,9 @@ int _sizeof_dtype(const std::string &dtype) {
     return sizeof(float);
   if (dtype == "float64")
     return sizeof(double);
-  return sizeof(std::uint16_t); // default to 16-bit float size
+  if (dtype == "float16")
+    return sizeof(std::uint16_t);
+  throw TrxDTypeError("Unrecognized dtype: " + dtype);
 }
 
 std::string _get_dtype(const std::string &dtype) {

--- a/tests/test_trx_mmap.cpp
+++ b/tests/test_trx_mmap.cpp
@@ -526,7 +526,8 @@ TEST(TrxFileMemmap, __sizeof_dtype_values) {
   EXPECT_EQ(trx::detail::_sizeof_dtype("int64"), sizeof(int64_t));
   EXPECT_EQ(trx::detail::_sizeof_dtype("float32"), sizeof(float));
   EXPECT_EQ(trx::detail::_sizeof_dtype("float64"), sizeof(double));
-  EXPECT_EQ(trx::detail::_sizeof_dtype("unknown"), sizeof(uint16_t));
+  EXPECT_EQ(trx::detail::_sizeof_dtype("float16"), sizeof(uint16_t));
+  EXPECT_THROW(trx::detail::_sizeof_dtype("unknown"), trx::TrxDTypeError);
 }
 
 // asserts dtype code mapping.


### PR DESCRIPTION
Root Cause: ext.substr(1, ext.size() - 1) bug in trx-cpp at trx.tpp:362

  The crash is caused by a bug in trx-cpp's _create_trx_from_pointer function at trx.tpp:362:
```c++
  trx->streamlines->mmap_pos =
      trx::_create_memmap(filename, shape, "r+", ext.substr(1, ext.size() - 1), mem_adress);
```

  _split_ext_with_dimensionality returns ext = "float32" (no leading dot). The ext.substr(1, 6) produces "loat32", which is passed to _create_memmap as the dtype.

  In _create_memmap (trx.cpp:751-753), the filesize is calculated as:
  filesize = rows * cols * _sizeof_dtype(dtype)

  _sizeof_dtype("loat32") matches no known dtype and falls through to the default return of sizeof(uint16_t) = 2 (dtype_helpers.cpp:30). For float32 data it should
  return 4.

  This means the positions mmap is created at half the required size:
  - 5000 vertices × 3 × 2 = 30,000 bytes mapped
  - 5000 vertices × 3 × 4 = 60,000 bytes needed

  The Eigen::Map is then created with shape (5000, 3) over this undersized buffer. When build_streamline_aabbs() iterates all vertices, it reads beyond the mapped memory.

  Why Windows crashes but Linux doesn't:
  - Windows: MapViewOfFile provides exactly the requested 30,000 bytes. Accessing byte 30,000+ causes an immediate access violation.
  - Linux: mmap rounds up to page boundaries (30,000 → 32,768 bytes = 8 pages). This provides ~2,730 extra floats of accessible memory. With 5000 vertices the code still reads beyond 32,768 bytes, but Linux may be surviving due to the positions file's pages being in the page cache from the prior zip extraction, making the unmapped region coincidentally accessible (this is undefined behavior).