### PR TITLE
Too many open files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ test-data/*
 bench/results*
 **build-tests
 *.jsonl
+build-*

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -71,7 +71,9 @@ A DPS array stores one value per streamline. It has shape
 - Per-streamline cluster labels
 - Tractography algorithm weights
 
-DPS arrays live under ``dps/`` and are mapped into ``MMappedMatrix`` objects.
+DPS arrays live under ``dps/`` and are loaded as typed matrix fields. If the
+on-disk dtype differs from the requested typed reader dtype, values are
+converted during load.
 
 Groups
 ------
@@ -95,8 +97,9 @@ contain any number of scalar or vector arrays. Typical uses:
 - Per-bundle display color
 - Volume or surface-area estimates
 
-In trx-cpp, groups are ``MMappedMatrix<uint32_t>`` objects and DPG fields are
-``MMappedMatrix<DT>`` entries, both memory-mapped.
+In ``TrxFile<DT>``, groups are discovered at load time but loaded lazily on
+first ``get_group_members(name)`` access, then cached in memory. DPG fields are
+loaded as typed matrices (with dtype conversion when needed).
 
 Header
 ------

--- a/docs/reading.rst
+++ b/docs/reading.rst
@@ -62,10 +62,13 @@ Access groups
 
 .. code-block:: cpp
 
-   for (const auto& [name, indices] : trx.groups) {
+   // AnyTrxFile: groups are TypedArray values.
+   for (const auto& [name, arr] : trx.groups) {
      std::cout << "group " << name << ": "
-               << indices.size() << " streamlines\n";
+               << arr.rows << " streamlines\n";
    }
+
+   auto ids = trx.groups.at("CST_L").as_matrix<uint32_t>(); // (N, 1)
 
 Typed access via TrxFile<DT>
 ----------------------------
@@ -81,6 +84,16 @@ directly, avoiding element-wise conversion:
 
    // trx.streamlines->_data    is Eigen::Matrix<float, Dynamic, 3>
    // trx.streamlines->_offsets is Eigen::Matrix<uint64_t, Dynamic, 1>
+
+   // Groups are discovered at load time but loaded lazily on first access.
+   for (const auto& kv : trx.groups) {
+     const auto& name = kv.first;
+     const auto* group = trx.get_group_members(name); // lazy load + cache
+     if (group == nullptr) {
+       continue;
+     }
+     std::cout << name << ": " << group->_matrix.rows() << " members\n";
+   }
 
    reader->close();
 

--- a/include/trx/trx.h
+++ b/include/trx/trx.h
@@ -232,6 +232,7 @@ template <typename DT> struct ArraySequence {
   Eigen::Map<Eigen::Matrix<DT, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> _data;
   Eigen::Map<Eigen::Matrix<uint64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> _offsets;
   Eigen::Matrix<uint32_t, Eigen::Dynamic, 1> _lengths;
+  std::vector<DT> _data_owned;
   std::vector<uint64_t> _offsets_owned;
   mio::shared_mmap_sink mmap_pos;
   mio::shared_mmap_sink mmap_off;
@@ -245,6 +246,7 @@ template <typename DT> struct MMappedMatrix {
   const auto &matrix() const { return _matrix; }
 
   Eigen::Map<Eigen::Matrix<DT, Eigen::Dynamic, Eigen::Dynamic>> _matrix;
+  std::vector<DT> _matrix_owned;
   mio::shared_mmap_sink mmap;
 
   MMappedMatrix() : _matrix(nullptr, 1, 1) {}
@@ -253,11 +255,19 @@ template <typename DT> struct MMappedMatrix {
 template <typename DT> class TrxFile {
   // Access specifier
 public:
+  struct GroupBackingInfo {
+    std::string filename;
+    int rows = 0;
+    int cols = 0;
+    std::string dtype;
+    long long mem_offset = 0;
+  };
+
   // Data Members
   json header;
   std::unique_ptr<ArraySequence<DT>> streamlines;
 
-  std::map<std::string, std::unique_ptr<MMappedMatrix<uint32_t>>> groups; // vector of indices
+  mutable std::map<std::string, std::unique_ptr<MMappedMatrix<uint32_t>>> groups; // vector of indices
 
   // int or float --check python float precision (singletons)
   std::map<std::string, std::unique_ptr<MMappedMatrix<DT>>> data_per_streamline;
@@ -436,6 +446,7 @@ public:
 
   const MMappedMatrix<DT> *get_dps(const std::string &name) const;
   const ArraySequence<DT> *get_dpv(const std::string &name) const;
+  const MMappedMatrix<uint32_t> *get_group_members(const std::string &name) const;
   std::vector<std::array<DT, 3>> get_streamline(size_t streamline_index) const;
   template <typename Fn> void for_each_streamline(Fn &&fn) const;
 
@@ -528,6 +539,8 @@ public:
   int len();
 
 private:
+  void ensure_all_groups_loaded() const;
+  std::map<std::string, GroupBackingInfo> group_backing_info_;
   mutable std::vector<std::array<Eigen::half, 6>> aabb_cache_;
   /**
    * @brief Get the real size of data (ignoring zeros of preallocation)
@@ -547,8 +560,9 @@ struct TypedArray {
   int rows = 0;
   int cols = 0;
   mio::shared_mmap_sink mmap;
+  std::vector<std::uint8_t> owned;
 
-  bool empty() const { return rows == 0 || cols == 0 || mmap.data() == nullptr; }
+  bool empty() const { return rows == 0 || cols == 0 || (owned.empty() && mmap.data() == nullptr); }
   size_t size() const { return static_cast<size_t>(rows) * static_cast<size_t>(cols); }
 
   /**
@@ -593,7 +607,7 @@ struct TypedArray {
     if (empty()) {
       return {};
     }
-    return {reinterpret_cast<const std::uint8_t *>(mmap.data()),
+    return {reinterpret_cast<const std::uint8_t *>(data()),
             static_cast<size_t>(detail::_sizeof_dtype(dtype)) * size()};
   }
 
@@ -607,19 +621,39 @@ struct TypedArray {
     if (empty()) {
       return {};
     }
-    return {reinterpret_cast<std::uint8_t *>(mmap.data()), static_cast<size_t>(detail::_sizeof_dtype(dtype)) * size()};
+    return {reinterpret_cast<std::uint8_t *>(data()), static_cast<size_t>(detail::_sizeof_dtype(dtype)) * size()};
+  }
+
+  void materialize_to_owned() {
+    const auto bytes = to_bytes();
+    if (bytes.size > 0 && bytes.data != nullptr) {
+      owned.assign(bytes.data, bytes.data + bytes.size);
+    } else {
+      owned.clear();
+    }
+    mmap.unmap();
   }
 
 private:
-  const void *data() const { return mmap.data(); }
-  void *data() { return mmap.data(); }
+  const void *data() const {
+    if (!owned.empty()) {
+      return owned.data();
+    }
+    return mmap.data();
+  }
+  void *data() {
+    if (!owned.empty()) {
+      return owned.data();
+    }
+    return mmap.data();
+  }
 
   template <typename T> T *data_as() {
     const std::string expected = dtype_from_scalar<T>();
     if (dtype != expected) {
       throw std::invalid_argument("TypedArray dtype mismatch: expected " + expected + " got " + dtype);
     }
-    return reinterpret_cast<T *>(mmap.data());
+    return reinterpret_cast<T *>(data());
   }
 
   template <typename T> const T *data_as() const {
@@ -627,7 +661,7 @@ private:
     if (dtype != expected) {
       throw std::invalid_argument("TypedArray dtype mismatch: expected " + expected + " got " + dtype);
     }
-    return reinterpret_cast<const T *>(mmap.data());
+    return reinterpret_cast<const T *>(data());
   }
 };
 
@@ -1100,14 +1134,50 @@ TrxFile<DT>::compute_group_connectivity(ConnectivityMeasure measure, const std::
   std::vector<std::vector<uint32_t>> streamline_to_groups(num_streamlines_total);
   for (const auto &kv : this->groups) {
     const auto it_gid = group_to_id.find(kv.first);
-    if (it_gid == group_to_id.end() || kv.second == nullptr) {
+    if (it_gid == group_to_id.end()) {
       continue;
     }
     const size_t gid = it_gid->second;
-    const auto &mat = kv.second->_matrix;
-    const size_t n_ids = static_cast<size_t>(mat.size());
+    const uint32_t *ids_ptr = nullptr;
+    size_t n_ids = 0;
+    std::vector<uint32_t> tmp_ids;
+
+    if (kv.second != nullptr) {
+      const auto &mat = kv.second->_matrix;
+      ids_ptr = mat.data();
+      n_ids = static_cast<size_t>(mat.size());
+    } else {
+      auto b = this->group_backing_info_.find(kv.first);
+      if (b == this->group_backing_info_.end()) {
+        continue;
+      }
+      const size_t expected_ids = static_cast<size_t>(std::max(0, b->second.rows)) * static_cast<size_t>(std::max(0, b->second.cols));
+      tmp_ids.resize(expected_ids);
+      if (expected_ids > 0) {
+        std::ifstream in(b->second.filename, std::ios::binary);
+        if (!in.is_open()) {
+          continue;
+        }
+        if (b->second.mem_offset > 0) {
+          const std::streamoff byte_offset =
+              static_cast<std::streamoff>(b->second.mem_offset) * static_cast<std::streamoff>(sizeof(uint32_t));
+          in.seekg(byte_offset, std::ios::beg);
+          if (!in.good()) {
+            continue;
+          }
+        }
+        in.read(reinterpret_cast<char *>(tmp_ids.data()),
+                static_cast<std::streamsize>(expected_ids * sizeof(uint32_t)));
+        if (!in) {
+          continue;
+        }
+      }
+      ids_ptr = tmp_ids.data();
+      n_ids = tmp_ids.size();
+    }
+
     for (size_t n = 0; n < n_ids; ++n) {
-      const uint32_t sid = mat.data()[n];
+      const uint32_t sid = ids_ptr[n];
       if (static_cast<size_t>(sid) < num_streamlines_total) {
         streamline_to_groups[static_cast<size_t>(sid)].push_back(static_cast<uint32_t>(gid));
       }

--- a/include/trx/trx.tpp
+++ b/include/trx/trx.tpp
@@ -84,6 +84,63 @@ void materialize_sequence_data_and_unmap(ArraySequence<T> &sequence) {
   sequence.mmap_pos.unmap();
 }
 
+template <typename OutT, typename InT>
+void copy_cast_buffer(const InT *src, size_t n, std::vector<OutT> &dst) {
+  dst.resize(n);
+  for (size_t i = 0; i < n; ++i) {
+    dst[i] = static_cast<OutT>(src[i]);
+  }
+}
+
+template <typename OutT>
+void copy_cast_from_dtype_buffer(const void *src, size_t n, const std::string &dtype, std::vector<OutT> &dst) {
+  if (dtype == "uint8") {
+    copy_cast_buffer(reinterpret_cast<const uint8_t *>(src), n, dst); // NOLINT
+    return;
+  }
+  if (dtype == "uint16" || dtype == "ushort") {
+    copy_cast_buffer(reinterpret_cast<const uint16_t *>(src), n, dst); // NOLINT
+    return;
+  }
+  if (dtype == "uint32") {
+    copy_cast_buffer(reinterpret_cast<const uint32_t *>(src), n, dst); // NOLINT
+    return;
+  }
+  if (dtype == "uint64") {
+    copy_cast_buffer(reinterpret_cast<const uint64_t *>(src), n, dst); // NOLINT
+    return;
+  }
+  if (dtype == "int8") {
+    copy_cast_buffer(reinterpret_cast<const int8_t *>(src), n, dst); // NOLINT
+    return;
+  }
+  if (dtype == "int16") {
+    copy_cast_buffer(reinterpret_cast<const int16_t *>(src), n, dst); // NOLINT
+    return;
+  }
+  if (dtype == "int32") {
+    copy_cast_buffer(reinterpret_cast<const int32_t *>(src), n, dst); // NOLINT
+    return;
+  }
+  if (dtype == "int64") {
+    copy_cast_buffer(reinterpret_cast<const int64_t *>(src), n, dst); // NOLINT
+    return;
+  }
+  if (dtype == "float16") {
+    copy_cast_buffer(reinterpret_cast<const Eigen::half *>(src), n, dst); // NOLINT
+    return;
+  }
+  if (dtype == "float32") {
+    copy_cast_buffer(reinterpret_cast<const float *>(src), n, dst); // NOLINT
+    return;
+  }
+  if (dtype == "float64") {
+    copy_cast_buffer(reinterpret_cast<const double *>(src), n, dst); // NOLINT
+    return;
+  }
+  throw TrxDTypeError("Unsupported metadata dtype for conversion: " + dtype);
+}
+
 template <class Matrix> void write_binary(const std::string &filename, const Matrix &matrix) {
   std::ofstream out(filename, std::ios::out | std::ios::binary | std::ios::trunc);
   typename Matrix::Index rows = matrix.rows(), cols = matrix.cols();
@@ -453,8 +510,18 @@ TrxFile<DT>::_create_trx_from_pointer(json header,
         shape = std::make_tuple(static_cast<int>(trx->header["NB_STREAMLINES"].int_value()), nb_scalar);
       }
       trx->data_per_streamline[base]->mmap = trx::_create_memmap(filename, shape, "r+", ext, mem_adress);
-      trx::detail::remap(trx->data_per_streamline[base]->_matrix, trx->data_per_streamline[base]->mmap.data(), shape);
-      materialize_matrix_map_and_unmap(*trx->data_per_streamline[base]);
+      const std::string expected_dtype = dtype_from_scalar<DT>();
+      if (ext == expected_dtype) {
+        trx::detail::remap(trx->data_per_streamline[base]->_matrix, trx->data_per_streamline[base]->mmap.data(), shape);
+        materialize_matrix_map_and_unmap(*trx->data_per_streamline[base]);
+      } else {
+        const size_t n = static_cast<size_t>(std::get<0>(shape)) * static_cast<size_t>(std::get<1>(shape));
+        copy_cast_from_dtype_buffer<DT>(trx->data_per_streamline[base]->mmap.data(), n, ext,
+                                        trx->data_per_streamline[base]->_matrix_owned);
+        trx::detail::remap(trx->data_per_streamline[base]->_matrix,
+                           trx->data_per_streamline[base]->_matrix_owned.data(), shape);
+        trx->data_per_streamline[base]->mmap.unmap();
+      }
     }
 
     else if (folder == "dpv") {
@@ -468,7 +535,16 @@ TrxFile<DT>::_create_trx_from_pointer(json header,
         shape = std::make_tuple(static_cast<int>(trx->header["NB_VERTICES"].int_value()), nb_scalar);
       }
       trx->data_per_vertex[base]->mmap_pos = trx::_create_memmap(filename, shape, "r+", ext, mem_adress);
-      trx::detail::remap(trx->data_per_vertex[base]->_data, trx->data_per_vertex[base]->mmap_pos.data(), shape);
+      const std::string expected_dtype = dtype_from_scalar<DT>();
+      if (ext == expected_dtype) {
+        trx::detail::remap(trx->data_per_vertex[base]->_data, trx->data_per_vertex[base]->mmap_pos.data(), shape);
+      } else {
+        const size_t n = static_cast<size_t>(std::get<0>(shape)) * static_cast<size_t>(std::get<1>(shape));
+        copy_cast_from_dtype_buffer<DT>(trx->data_per_vertex[base]->mmap_pos.data(), n, ext,
+                                        trx->data_per_vertex[base]->_data_owned);
+        trx::detail::remap(trx->data_per_vertex[base]->_data, trx->data_per_vertex[base]->_data_owned.data(), shape);
+        trx->data_per_vertex[base]->mmap_pos.unmap();
+      }
       trx::detail::remap(trx->data_per_vertex[base]->_offsets, trx->streamlines->_offsets.data(),
                          int(trx->streamlines->_offsets.rows()), int(trx->streamlines->_offsets.cols()));
       trx->data_per_vertex[base]->_lengths = trx->streamlines->_lengths;
@@ -489,10 +565,19 @@ TrxFile<DT>::_create_trx_from_pointer(json header,
 
       trx->data_per_group[sub_folder][data_name] = std::make_unique<MMappedMatrix<DT>>();
       trx->data_per_group[sub_folder][data_name]->mmap = trx::_create_memmap(filename, shape, "r+", ext, mem_adress);
-
-      trx::detail::remap(trx->data_per_group[sub_folder][data_name]->_matrix,
-                         trx->data_per_group[sub_folder][data_name]->mmap.data(), shape);
-      materialize_matrix_map_and_unmap(*trx->data_per_group[sub_folder][data_name]);
+      const std::string expected_dtype = dtype_from_scalar<DT>();
+      if (ext == expected_dtype) {
+        trx::detail::remap(trx->data_per_group[sub_folder][data_name]->_matrix,
+                           trx->data_per_group[sub_folder][data_name]->mmap.data(), shape);
+        materialize_matrix_map_and_unmap(*trx->data_per_group[sub_folder][data_name]);
+      } else {
+        const size_t n = static_cast<size_t>(std::get<0>(shape)) * static_cast<size_t>(std::get<1>(shape));
+        copy_cast_from_dtype_buffer<DT>(trx->data_per_group[sub_folder][data_name]->mmap.data(), n, ext,
+                                        trx->data_per_group[sub_folder][data_name]->_matrix_owned);
+        trx::detail::remap(trx->data_per_group[sub_folder][data_name]->_matrix,
+                           trx->data_per_group[sub_folder][data_name]->_matrix_owned.data(), shape);
+        trx->data_per_group[sub_folder][data_name]->mmap.unmap();
+      }
     }
 
     else if (folder == "groups") {

--- a/include/trx/trx.tpp
+++ b/include/trx/trx.tpp
@@ -54,6 +54,36 @@ inline std::string folder_from_path(const std::string &elem_filename, const std:
   return folder;
 }
 
+template <typename T>
+void materialize_matrix_map_and_unmap(MMappedMatrix<T> &mapped_matrix) {
+  const int rows = mapped_matrix._matrix.rows();
+  const int cols = mapped_matrix._matrix.cols();
+  const size_t n = static_cast<size_t>(rows) * static_cast<size_t>(cols);
+  mapped_matrix._matrix_owned.resize(n);
+  if (n > 0) {
+    std::copy_n(mapped_matrix._matrix.data(), n, mapped_matrix._matrix_owned.data());
+    trx::detail::remap(mapped_matrix._matrix, mapped_matrix._matrix_owned.data(), rows, cols);
+  } else {
+    trx::detail::remap(mapped_matrix._matrix, static_cast<T *>(nullptr), rows, cols);
+  }
+  mapped_matrix.mmap.unmap();
+}
+
+template <typename T>
+void materialize_sequence_data_and_unmap(ArraySequence<T> &sequence) {
+  const int rows = sequence._data.rows();
+  const int cols = sequence._data.cols();
+  const size_t n = static_cast<size_t>(rows) * static_cast<size_t>(cols);
+  sequence._data_owned.resize(n);
+  if (n > 0) {
+    std::copy_n(sequence._data.data(), n, sequence._data_owned.data());
+    trx::detail::remap(sequence._data, sequence._data_owned.data(), rows, cols);
+  } else {
+    trx::detail::remap(sequence._data, static_cast<T *>(nullptr), rows, cols);
+  }
+  sequence.mmap_pos.unmap();
+}
+
 template <class Matrix> void write_binary(const std::string &filename, const Matrix &matrix) {
   std::ofstream out(filename, std::ios::out | std::ios::binary | std::ios::trunc);
   typename Matrix::Index rows = matrix.rows(), cols = matrix.cols();
@@ -424,6 +454,7 @@ TrxFile<DT>::_create_trx_from_pointer(json header,
       }
       trx->data_per_streamline[base]->mmap = trx::_create_memmap(filename, shape, "r+", ext, mem_adress);
       trx::detail::remap(trx->data_per_streamline[base]->_matrix, trx->data_per_streamline[base]->mmap.data(), shape);
+      materialize_matrix_map_and_unmap(*trx->data_per_streamline[base]);
     }
 
     else if (folder == "dpv") {
@@ -461,6 +492,7 @@ TrxFile<DT>::_create_trx_from_pointer(json header,
 
       trx::detail::remap(trx->data_per_group[sub_folder][data_name]->_matrix,
                          trx->data_per_group[sub_folder][data_name]->mmap.data(), shape);
+      materialize_matrix_map_and_unmap(*trx->data_per_group[sub_folder][data_name]);
     }
 
     else if (folder == "groups") {
@@ -470,9 +502,14 @@ TrxFile<DT>::_create_trx_from_pointer(json header,
       } else {
         shape = std::make_tuple(static_cast<int>(size), 1);
       }
-      trx->groups[base] = std::make_unique<MMappedMatrix<uint32_t>>();
-      trx->groups[base]->mmap = trx::_create_memmap(filename, shape, "r+", ext, mem_adress);
-      trx::detail::remap(trx->groups[base]->_matrix, trx->groups[base]->mmap.data(), shape);
+      trx->groups[base] = nullptr;
+      typename TrxFile<DT>::GroupBackingInfo info;
+      info.filename = filename;
+      info.rows = std::get<0>(shape);
+      info.cols = std::get<1>(shape);
+      info.dtype = ext;
+      info.mem_offset = mem_adress;
+      trx->group_backing_info_[base] = std::move(info);
     } else {
       throw TrxFormatError("Entry is not part of a valid TRX structure: " + elem_filename);
     }
@@ -545,6 +582,7 @@ template <typename DT> std::unique_ptr<TrxFile<DT>> TrxFile<DT>::deepcopy() {
   // Copy groups (not covered by _initialize_empty_trx)
   std::string tmp_dir = copy->_uncompressed_folder_handle;
   if (!this->groups.empty()) {
+    this->ensure_all_groups_loaded();
     std::string groups_dirname = tmp_dir + SEPARATOR + "groups" + SEPARATOR;
     {
       std::error_code ec;
@@ -671,6 +709,7 @@ template <typename DT> void TrxFile<DT>::close() {
   this->_cleanup_temporary_directory();
   this->streamlines.reset();
   this->groups.clear();
+  this->group_backing_info_.clear();
   this->data_per_streamline.clear();
   this->data_per_vertex.clear();
   this->data_per_group.clear();
@@ -747,6 +786,7 @@ void TrxFile<DT>::resize(int nb_streamlines, int nb_vertices, bool delete_dpg) {
   std::string tmp_dir = trx->_uncompressed_folder_handle;
 
   if (this->groups.size() > 0) {
+    this->ensure_all_groups_loaded();
     std::string group_dir = tmp_dir + SEPARATOR + "groups" + SEPARATOR;
     mkdir_or_throw(group_dir);
 
@@ -1337,6 +1377,10 @@ void TrxFile<DT>::add_group_from_indices(const std::string &name, const std::vec
   auto existing = this->groups.find(name);
   if (existing != this->groups.end()) {
     this->groups.erase(existing);
+  }
+  auto backing = this->group_backing_info_.find(name);
+  if (backing != this->group_backing_info_.end()) {
+    this->group_backing_info_.erase(backing);
   }
 
   const int rows = static_cast<int>(indices.size());
@@ -2606,6 +2650,38 @@ const ArraySequence<DT> *TrxFile<DT>::get_dpv(const std::string &name) const {
 }
 
 template <typename DT>
+const MMappedMatrix<uint32_t> *TrxFile<DT>::get_group_members(const std::string &name) const {
+  auto it = this->groups.find(name);
+  if (it == this->groups.end()) {
+    return nullptr;
+  }
+  if (!it->second) {
+    auto b = this->group_backing_info_.find(name);
+    if (b == this->group_backing_info_.end()) {
+      return nullptr;
+    }
+    std::tuple<int, int> shape = std::make_tuple(b->second.rows, b->second.cols);
+    it->second = std::make_unique<MMappedMatrix<uint32_t>>();
+    it->second->mmap = trx::_create_memmap(b->second.filename, shape, "r+", b->second.dtype, b->second.mem_offset);
+    trx::detail::remap(it->second->_matrix, it->second->mmap.data(), shape);
+    materialize_matrix_map_and_unmap(*it->second);
+  }
+  return it->second.get();
+}
+
+template <typename DT>
+void TrxFile<DT>::ensure_all_groups_loaded() const {
+  std::vector<std::string> names;
+  names.reserve(this->groups.size());
+  for (const auto &kv : this->groups) {
+    names.push_back(kv.first);
+  }
+  for (const auto &name : names) {
+    static_cast<void>(this->get_group_members(name));
+  }
+}
+
+template <typename DT>
 std::vector<std::array<DT, 3>> TrxFile<DT>::get_streamline(size_t streamline_index) const {
   if (!this->streamlines || this->streamlines->_offsets.size() == 0) {
     throw TrxFormatError("TRX streamlines are not available");
@@ -2904,7 +2980,11 @@ std::unique_ptr<TrxFile<DT>> TrxFile<DT>::subset_streamlines(const std::vector<u
   for (const auto &kv : this->groups) {
     const std::string &group_name = kv.first;
     std::vector<uint32_t> indices;
-    auto &matrix = kv.second->_matrix;
+    const auto *group = this->get_group_members(group_name);
+    if (group == nullptr) {
+      continue;
+    }
+    const auto &matrix = group->_matrix;
     indices.reserve(static_cast<size_t>(matrix.size()));
     for (Eigen::Index r = 0; r < matrix.rows(); ++r) {
       for (Eigen::Index c = 0; c < matrix.cols(); ++c) {

--- a/include/trx/trx.tpp
+++ b/include/trx/trx.tpp
@@ -706,13 +706,13 @@ TrxFile<DT>::_copy_fixed_arrays_from(TrxFile<DT> *trx, int strs_start, int pts_s
 }
 
 template <typename DT> void TrxFile<DT>::close() {
-  this->_cleanup_temporary_directory();
   this->streamlines.reset();
   this->groups.clear();
   this->group_backing_info_.clear();
   this->data_per_streamline.clear();
   this->data_per_vertex.clear();
   this->data_per_group.clear();
+  this->_cleanup_temporary_directory();
   this->_uncompressed_folder_handle.clear();
   this->_owns_uncompressed_folder = false;
   this->_copy_safe = true;
@@ -730,7 +730,17 @@ template <typename DT> void TrxFile<DT>::close() {
   this->header = json(header_obj);
 }
 
-template <typename DT> TrxFile<DT>::~TrxFile() { this->_cleanup_temporary_directory(); }
+template <typename DT>
+TrxFile<DT>::~TrxFile() {
+  // Release mmap-backed members before deleting temporary backing directory.
+  this->streamlines.reset();
+  this->groups.clear();
+  this->group_backing_info_.clear();
+  this->data_per_streamline.clear();
+  this->data_per_vertex.clear();
+  this->data_per_group.clear();
+  this->_cleanup_temporary_directory();
+}
 
 template <typename DT>
 // Caveat: cleanup is best-effort; filesystem errors are ignored.
@@ -2660,11 +2670,37 @@ const MMappedMatrix<uint32_t> *TrxFile<DT>::get_group_members(const std::string 
     if (b == this->group_backing_info_.end()) {
       return nullptr;
     }
-    std::tuple<int, int> shape = std::make_tuple(b->second.rows, b->second.cols);
+    const int rows = b->second.rows;
+    const int cols = b->second.cols;
+    std::tuple<int, int> shape = std::make_tuple(rows, cols);
     it->second = std::make_unique<MMappedMatrix<uint32_t>>();
-    it->second->mmap = trx::_create_memmap(b->second.filename, shape, "r+", b->second.dtype, b->second.mem_offset);
-    trx::detail::remap(it->second->_matrix, it->second->mmap.data(), shape);
-    materialize_matrix_map_and_unmap(*it->second);
+    const size_t n = static_cast<size_t>(std::max(0, rows)) * static_cast<size_t>(std::max(0, cols));
+    it->second->_matrix_owned.resize(n);
+
+    if (n > 0) {
+      std::ifstream in(b->second.filename, std::ios::binary);
+      if (!in.is_open()) {
+        it->second.reset();
+        return nullptr;
+      }
+      if (b->second.mem_offset > 0) {
+        const std::streamoff byte_offset =
+            static_cast<std::streamoff>(b->second.mem_offset) * static_cast<std::streamoff>(sizeof(uint32_t));
+        in.seekg(byte_offset, std::ios::beg);
+        if (!in.good()) {
+          it->second.reset();
+          return nullptr;
+        }
+      }
+      in.read(reinterpret_cast<char *>(it->second->_matrix_owned.data()), static_cast<std::streamsize>(n * sizeof(uint32_t)));
+      if (!in) {
+        it->second.reset();
+        return nullptr;
+      }
+      trx::detail::remap(it->second->_matrix, it->second->_matrix_owned.data(), shape);
+    } else {
+      trx::detail::remap(it->second->_matrix, static_cast<uint32_t *>(nullptr), shape);
+    }
   }
   return it->second.get();
 }

--- a/src/trx.cpp
+++ b/src/trx.cpp
@@ -207,7 +207,16 @@ bool is_trx_directory(const std::string &path) {
   return trx::fs::is_directory(input, ec) && !ec;
 }
 
-AnyTrxFile::~AnyTrxFile() { _cleanup_temporary_directory(); }
+AnyTrxFile::~AnyTrxFile() {
+  // Release mmap-backed members before deleting temporary backing directory.
+  positions = TypedArray();
+  offsets = TypedArray();
+  groups.clear();
+  data_per_streamline.clear();
+  data_per_vertex.clear();
+  data_per_group.clear();
+  _cleanup_temporary_directory();
+}
 
 std::string AnyTrxFile::_normalize_dtype(const std::string &dtype) {
   if (dtype == "bool") {
@@ -274,7 +283,6 @@ std::vector<std::array<double, 3>> AnyTrxFile::get_streamline(size_t streamline_
 }
 
 void AnyTrxFile::close() {
-  _cleanup_temporary_directory();
   positions = TypedArray();
   offsets = TypedArray();
   offsets_u64.clear();
@@ -283,6 +291,7 @@ void AnyTrxFile::close() {
   data_per_streamline.clear();
   data_per_vertex.clear();
   data_per_group.clear();
+  _cleanup_temporary_directory();
   _uncompressed_folder_handle.clear();
   _owns_uncompressed_folder = false;
 

--- a/src/trx.cpp
+++ b/src/trx.cpp
@@ -435,21 +435,26 @@ AnyTrxFile::_create_from_pointer(json header,
       if (nb_streamlines == 0 || size % nb_streamlines != 0 || nb_scalar != dim) {
         throw TrxFormatError("Wrong dps size/dimensionality");
       }
-      trx.data_per_streamline.emplace(base, make_typed_array(elem_filename, nb_streamlines, nb_scalar, ext));
+      auto arr = make_typed_array(elem_filename, nb_streamlines, nb_scalar, ext);
+      arr.materialize_to_owned();
+      trx.data_per_streamline.emplace(base, std::move(arr));
     } else if (folder == "dpv") {
       const int nb_scalar = nb_vertices > 0 ? static_cast<int>(size / nb_vertices) : 0;
       if (nb_vertices == 0 || size % nb_vertices != 0 || nb_scalar != dim) {
         throw TrxFormatError("Wrong dpv size/dimensionality");
       }
-      trx.data_per_vertex.emplace(base, make_typed_array(elem_filename, nb_vertices, nb_scalar, ext));
+      auto arr = make_typed_array(elem_filename, nb_vertices, nb_scalar, ext);
+      arr.materialize_to_owned();
+      trx.data_per_vertex.emplace(base, std::move(arr));
     } else if (folder.rfind("dpg", 0) == 0) {
       if (size != dim) {
         throw TrxFormatError("Wrong dpg size/dimensionality");
       }
       std::string data_name = path_basename(base);
       std::string sub_folder = path_basename(folder);
-      trx.data_per_group[sub_folder].emplace(data_name,
-                                             make_typed_array(elem_filename, 1, static_cast<int>(size), ext));
+      auto arr = make_typed_array(elem_filename, 1, static_cast<int>(size), ext);
+      arr.materialize_to_owned();
+      trx.data_per_group[sub_folder].emplace(data_name, std::move(arr));
     } else if (folder == "groups") {
       if (dim != 1) {
         throw TrxFormatError("Wrong group dimensionality");
@@ -457,7 +462,9 @@ AnyTrxFile::_create_from_pointer(json header,
       if (ext != "uint32") {
         throw TrxDTypeError("Unsupported group dtype: " + ext);
       }
-      trx.groups.emplace(base, make_typed_array(elem_filename, static_cast<int>(size), 1, ext));
+      auto arr = make_typed_array(elem_filename, static_cast<int>(size), 1, ext);
+      arr.materialize_to_owned();
+      trx.groups.emplace(base, std::move(arr));
     } else {
       throw TrxFormatError("Entry is not part of a valid TRX structure: " + elem_filename);
     }

--- a/tests/test_trx_mmap.cpp
+++ b/tests/test_trx_mmap.cpp
@@ -703,6 +703,114 @@ TEST(TrxFileMemmap, load_directory_test_data) {
   EXPECT_GT(trx->streamlines->_data.size(), 0);
 }
 
+TEST(TrxFileMemmap, load_mixed_metadata_dtype_into_half_reader) {
+  const fs::path out_dir = make_temp_test_dir("trx_mixed_meta_dtype");
+  const fs::path out_path = out_dir / "mixed.trx";
+
+  trx::TrxStream stream("float16");
+  stream.push_streamline(std::vector<float>{0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f});
+  stream.push_streamline(std::vector<float>{2.0f, 2.0f, 2.0f, 3.0f, 3.0f, 3.0f});
+  stream.push_dps_from_vector("dps1", "float32", std::vector<float>{1.0f, 4.0f});
+  stream.push_dpv_from_vector("dpv1", "float32", std::vector<float>{100.0f, 101.0f, 106.0f, 107.0f});
+  stream.finalize<float>(out_path.string(), ZIP_CM_STORE);
+
+  trx::TrxReader<half> reader(out_path.string());
+  auto *trx = reader.get();
+  ASSERT_NE(trx, nullptr);
+  ASSERT_NE(trx->streamlines, nullptr);
+  EXPECT_GT(trx->streamlines->_data.size(), 0);
+
+  auto dps_it = trx->data_per_streamline.find("dps1");
+  ASSERT_NE(dps_it, trx->data_per_streamline.end());
+  EXPECT_FLOAT_EQ(static_cast<float>(dps_it->second->_matrix(0, 0)), 1.0f);
+  EXPECT_FLOAT_EQ(static_cast<float>(dps_it->second->_matrix(1, 0)), 4.0f);
+
+  auto dpv_it = trx->data_per_vertex.find("dpv1");
+  ASSERT_NE(dpv_it, trx->data_per_vertex.end());
+  EXPECT_FLOAT_EQ(static_cast<float>(dpv_it->second->_data(0, 0)), 100.0f);
+  EXPECT_FLOAT_EQ(static_cast<float>(dpv_it->second->_data(3, 0)), 107.0f);
+
+  trx->close();
+  std::error_code ec;
+  fs::remove_all(out_dir, ec);
+}
+
+TEST(TrxFileMemmap, load_multiple_metadata_dtypes_into_half_reader) {
+  const fs::path out_dir = make_temp_test_dir("trx_multi_meta_dtype");
+  const fs::path dir_path = out_dir / "multi_fldr.trx";
+  std::error_code ec;
+  fs::create_directories(dir_path / "dps", ec);
+  fs::create_directories(dir_path / "dpv", ec);
+
+  json::object header_obj;
+  header_obj["DIMENSIONS"] = json::array{1, 1, 1};
+  header_obj["NB_STREAMLINES"] = 2;
+  header_obj["NB_VERTICES"] = 4;
+  header_obj["VOXEL_TO_RASMM"] = json::array{
+      json::array{1.0, 0.0, 0.0, 0.0},
+      json::array{0.0, 1.0, 0.0, 0.0},
+      json::array{0.0, 0.0, 1.0, 0.0},
+      json::array{0.0, 0.0, 0.0, 1.0},
+  };
+  std::ofstream header_out((dir_path / "header.json").string());
+  ASSERT_TRUE(header_out.is_open());
+  header_out << json(header_obj).dump() << std::endl;
+  header_out.close();
+
+  Matrix<half, Dynamic, Dynamic, RowMajor> positions(4, 3);
+  positions.setZero();
+  trx::write_binary((dir_path / "positions.3.float16").string(), positions);
+
+  Matrix<uint32_t, Dynamic, Dynamic, RowMajor> offsets(3, 1);
+  offsets << 0, 2, 4;
+  trx::write_binary((dir_path / "offsets.uint32").string(), offsets);
+
+  // DPS with mixed dtypes
+  Matrix<float, Dynamic, Dynamic, RowMajor> dps_f32(2, 1);
+  dps_f32 << 1.5f, -2.5f;
+  trx::write_binary((dir_path / "dps" / "dps_f32.float32").string(), dps_f32);
+
+  Matrix<int16_t, Dynamic, Dynamic, RowMajor> dps_i16(2, 1);
+  dps_i16 << 7, -8;
+  trx::write_binary((dir_path / "dps" / "dps_i16.int16").string(), dps_i16);
+
+  // DPV with mixed dtypes
+  Matrix<double, Dynamic, Dynamic, RowMajor> dpv_f64(4, 1);
+  dpv_f64 << 1.25, 2.5, 3.75, 5.0;
+  trx::write_binary((dir_path / "dpv" / "dpv_f64.float64").string(), dpv_f64);
+
+  Matrix<uint8_t, Dynamic, Dynamic, RowMajor> dpv_u8(4, 1);
+  dpv_u8 << 15, 16, 17, 18;
+  trx::write_binary((dir_path / "dpv" / "dpv_u8.uint8").string(), dpv_u8);
+
+  trx::TrxReader<half> reader(dir_path.string());
+  auto *trx = reader.get();
+  ASSERT_NE(trx, nullptr);
+  ASSERT_NE(trx->streamlines, nullptr);
+  EXPECT_GT(trx->streamlines->_data.size(), 0);
+
+  auto expect_dps = [&](const std::string &name, float v0, float v1) {
+    auto it = trx->data_per_streamline.find(name);
+    ASSERT_NE(it, trx->data_per_streamline.end()) << "missing DPS: " << name;
+    EXPECT_FLOAT_EQ(static_cast<float>(it->second->_matrix(0, 0)), v0);
+    EXPECT_FLOAT_EQ(static_cast<float>(it->second->_matrix(1, 0)), v1);
+  };
+  expect_dps("dps_f32", 1.5f, -2.5f);
+  expect_dps("dps_i16", 7.0f, -8.0f);
+
+  auto expect_dpv = [&](const std::string &name, float v0, float v3) {
+    auto it = trx->data_per_vertex.find(name);
+    ASSERT_NE(it, trx->data_per_vertex.end()) << "missing DPV: " << name;
+    EXPECT_FLOAT_EQ(static_cast<float>(it->second->_data(0, 0)), v0);
+    EXPECT_FLOAT_EQ(static_cast<float>(it->second->_data(3, 0)), v3);
+  };
+  expect_dpv("dpv_f64", 1.25f, 5.0f);
+  expect_dpv("dpv_u8", 15.0f, 18.0f);
+
+  trx->close();
+  fs::remove_all(out_dir, ec);
+}
+
 // Mirrors trx/tests/test_memmap.py::test_load with missing path raising.
 TEST(TrxFileMemmap, load_missing_trx_throws) {
   const auto root = get_test_data_root();

--- a/tests/test_trx_trxfile.cpp
+++ b/tests/test_trx_trxfile.cpp
@@ -7,9 +7,14 @@
 #include <filesystem>
 #include <gtest/gtest.h>
 
+#include <cerrno>
+#include <cstring>
 #include <fstream>
 #include <random>
 #include <set>
+#if !defined(_WIN32) && !defined(_WIN64)
+#include <sys/resource.h>
+#endif
 
 using namespace Eigen;
 using namespace trx;
@@ -161,6 +166,231 @@ fs::path create_connectivity_fixture_trx() {
 
   return out_path;
 }
+
+fs::path create_many_groups_fixture_trx(size_t group_count, size_t streamline_count = 16) {
+  fs::path root = make_temp_test_dir("trx_many_groups_fixture");
+  const fs::path out_path = root / "many_groups.trx";
+
+  TrxStream stream;
+  for (size_t i = 0; i < streamline_count; ++i) {
+    stream.push_streamline(std::vector<float>{0.0f, 0.0f, 0.0f});
+  }
+
+  for (size_t g = 0; g < group_count; ++g) {
+    const std::string name = "G" + std::to_string(g);
+    const uint32_t sid = static_cast<uint32_t>(g % streamline_count);
+    stream.push_group_from_indices(name, {sid});
+  }
+  stream.finalize<float>(out_path.string(), ZIP_CM_STORE);
+
+  return out_path;
+}
+
+fs::path create_connectivity_bad_dps_fixture_dir() {
+  fs::path root = make_temp_test_dir("trx_connectivity_bad_dps_fixture");
+  fs::path header_path = root / "header.json";
+
+  json::object header_obj;
+  header_obj["DIMENSIONS"] = json::array{1, 1, 1};
+  header_obj["NB_STREAMLINES"] = 2;
+  header_obj["NB_VERTICES"] = 2;
+  header_obj["VOXEL_TO_RASMM"] = json::array{
+      json::array{1.0, 0.0, 0.0, 0.0},
+      json::array{0.0, 1.0, 0.0, 0.0},
+      json::array{0.0, 0.0, 1.0, 0.0},
+      json::array{0.0, 0.0, 0.0, 1.0},
+  };
+  json header(header_obj);
+
+  std::ofstream header_out(header_path.string());
+  if (!header_out.is_open()) {
+    throw std::runtime_error("Failed to write header.json");
+  }
+  header_out << header.dump() << std::endl;
+  header_out.close();
+
+  Matrix<float, Dynamic, Dynamic, RowMajor> positions(2, 3);
+  positions << 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f;
+  trx::write_binary((root / "positions.3.float32").string(), positions);
+
+  Matrix<uint32_t, Dynamic, Dynamic, RowMajor> offsets(3, 1);
+  offsets << 0, 1, 2;
+  trx::write_binary((root / "offsets.uint32").string(), offsets);
+
+  fs::path groups_dir = root / "groups";
+  std::error_code ec;
+  fs::create_directories(groups_dir, ec);
+  Matrix<uint32_t, Dynamic, Dynamic, RowMajor> group_vals(2, 1);
+  group_vals << 0, 1;
+  trx::write_binary((groups_dir / "A.uint32").string(), group_vals);
+
+  fs::path dps_dir = root / "dps";
+  fs::create_directories(dps_dir, ec);
+  Matrix<float, Dynamic, Dynamic, RowMajor> dps(2, 2);
+  dps << 1.0f, 2.0f, 3.0f, 4.0f;
+  trx::write_binary((dps_dir / "weights2d.2.float32").string(), dps);
+
+  return root;
+}
+
+fs::path create_connectivity_no_groups_fixture_trx(size_t streamline_count = 3) {
+  fs::path root = make_temp_test_dir("trx_connectivity_nogroups");
+  const fs::path out_path = root / "nogroups.trx";
+
+  TrxStream stream;
+  for (size_t i = 0; i < streamline_count; ++i) {
+    stream.push_streamline(std::vector<float>{0.0f, 0.0f, 0.0f});
+  }
+  stream.finalize<float>(out_path.string(), ZIP_CM_STORE);
+  return out_path;
+}
+
+fs::path create_connectivity_empty_group_fixture_dir() {
+  fs::path root = make_temp_test_dir("trx_connectivity_empty_group");
+  fs::path header_path = root / "header.json";
+
+  json::object header_obj;
+  header_obj["DIMENSIONS"] = json::array{1, 1, 1};
+  header_obj["NB_STREAMLINES"] = 3;
+  header_obj["NB_VERTICES"] = 3;
+  header_obj["VOXEL_TO_RASMM"] = json::array{
+      json::array{1.0, 0.0, 0.0, 0.0},
+      json::array{0.0, 1.0, 0.0, 0.0},
+      json::array{0.0, 0.0, 1.0, 0.0},
+      json::array{0.0, 0.0, 0.0, 1.0},
+  };
+  json header(header_obj);
+
+  std::ofstream header_out(header_path.string());
+  if (!header_out.is_open()) {
+    throw std::runtime_error("Failed to write header.json");
+  }
+  header_out << header.dump() << std::endl;
+  header_out.close();
+
+  Matrix<float, Dynamic, Dynamic, RowMajor> positions(3, 3);
+  positions << 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 2.0f, 2.0f, 2.0f;
+  trx::write_binary((root / "positions.3.float32").string(), positions);
+
+  Matrix<uint32_t, Dynamic, Dynamic, RowMajor> offsets(4, 1);
+  offsets << 0, 1, 2, 3;
+  trx::write_binary((root / "offsets.uint32").string(), offsets);
+
+  std::error_code ec;
+  const fs::path groups_dir = root / "groups";
+  fs::create_directories(groups_dir, ec);
+  // Empty file -> valid empty group membership list.
+  std::ofstream((groups_dir / "Empty.uint32").string(), std::ios::binary | std::ios::trunc).close();
+
+  return root;
+}
+
+fs::path create_connectivity_out_of_range_group_fixture_dir() {
+  fs::path root = make_temp_test_dir("trx_connectivity_out_of_range");
+  fs::path header_path = root / "header.json";
+
+  json::object header_obj;
+  header_obj["DIMENSIONS"] = json::array{1, 1, 1};
+  header_obj["NB_STREAMLINES"] = 3;
+  header_obj["NB_VERTICES"] = 3;
+  header_obj["VOXEL_TO_RASMM"] = json::array{
+      json::array{1.0, 0.0, 0.0, 0.0},
+      json::array{0.0, 1.0, 0.0, 0.0},
+      json::array{0.0, 0.0, 1.0, 0.0},
+      json::array{0.0, 0.0, 0.0, 1.0},
+  };
+  json header(header_obj);
+
+  std::ofstream header_out(header_path.string());
+  if (!header_out.is_open()) {
+    throw std::runtime_error("Failed to write header.json");
+  }
+  header_out << header.dump() << std::endl;
+  header_out.close();
+
+  Matrix<float, Dynamic, Dynamic, RowMajor> positions(3, 3);
+  positions << 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 2.0f, 2.0f, 2.0f;
+  trx::write_binary((root / "positions.3.float32").string(), positions);
+
+  Matrix<uint32_t, Dynamic, Dynamic, RowMajor> offsets(4, 1);
+  offsets << 0, 1, 2, 3;
+  trx::write_binary((root / "offsets.uint32").string(), offsets);
+
+  std::error_code ec;
+  const fs::path groups_dir = root / "groups";
+  fs::create_directories(groups_dir, ec);
+  Matrix<uint32_t, Dynamic, Dynamic, RowMajor> group_vals(3, 1);
+  // Index 99 is out-of-range and should be ignored by connectivity builder.
+  group_vals << 0, 2, 99;
+  trx::write_binary((groups_dir / "A.uint32").string(), group_vals);
+
+  return root;
+}
+
+fs::path create_connectivity_large_lazy_group_fixture_dir(size_t streamline_count = 100000,
+                                                          size_t duplicate_factor = 5) {
+  fs::path root = make_temp_test_dir("trx_connectivity_large_lazy_group");
+  fs::path header_path = root / "header.json";
+
+  json::object header_obj;
+  header_obj["DIMENSIONS"] = json::array{1, 1, 1};
+  header_obj["NB_STREAMLINES"] = static_cast<int>(streamline_count);
+  header_obj["NB_VERTICES"] = static_cast<int>(streamline_count);
+  header_obj["VOXEL_TO_RASMM"] = json::array{
+      json::array{1.0, 0.0, 0.0, 0.0},
+      json::array{0.0, 1.0, 0.0, 0.0},
+      json::array{0.0, 0.0, 1.0, 0.0},
+      json::array{0.0, 0.0, 0.0, 1.0},
+  };
+  json header(header_obj);
+
+  std::ofstream header_out(header_path.string());
+  if (!header_out.is_open()) {
+    throw std::runtime_error("Failed to write header.json");
+  }
+  header_out << header.dump() << std::endl;
+  header_out.close();
+
+  Matrix<float, Dynamic, Dynamic, RowMajor> positions(static_cast<Eigen::Index>(streamline_count), 3);
+  for (size_t i = 0; i < streamline_count; ++i) {
+    const auto row = static_cast<Eigen::Index>(i);
+    positions(row, 0) = static_cast<float>(i);
+    positions(row, 1) = 0.0f;
+    positions(row, 2) = 0.0f;
+  }
+  trx::write_binary((root / "positions.3.float32").string(), positions);
+
+  Matrix<uint32_t, Dynamic, Dynamic, RowMajor> offsets(static_cast<Eigen::Index>(streamline_count + 1), 1);
+  for (size_t i = 0; i <= streamline_count; ++i) {
+    offsets(static_cast<Eigen::Index>(i), 0) = static_cast<uint32_t>(i);
+  }
+  trx::write_binary((root / "offsets.uint32").string(), offsets);
+
+  std::error_code ec;
+  const fs::path groups_dir = root / "groups";
+  fs::create_directories(groups_dir, ec);
+  const size_t n_ids = streamline_count * duplicate_factor;
+  Matrix<uint32_t, Dynamic, Dynamic, RowMajor> group_vals(static_cast<Eigen::Index>(n_ids), 1);
+  for (size_t i = 0; i < n_ids; ++i) {
+    group_vals(static_cast<Eigen::Index>(i), 0) = static_cast<uint32_t>(i % streamline_count);
+  }
+  trx::write_binary((groups_dir / "All.uint32").string(), group_vals);
+
+  return root;
+}
+
+#if !defined(_WIN32) && !defined(_WIN64)
+struct NoFileLimitRestoreGuard {
+  rlimit old_limit{};
+  bool active = false;
+
+  ~NoFileLimitRestoreGuard() {
+    if (active) {
+      static_cast<void>(setrlimit(RLIMIT_NOFILE, &old_limit));
+    }
+  }
+};
+#endif
 } // namespace
 
 TEST(TrxFileTpp, DeepcopyEmpty) {
@@ -207,9 +437,13 @@ TEST(TrxFileTpp, DeepcopyWithGroupsDpgDpvDps) {
   for (const auto &kv : trx->groups) {
     auto it = copy->groups.find(kv.first);
     ASSERT_NE(it, copy->groups.end());
-    EXPECT_EQ(it->second->_matrix.rows(), kv.second->_matrix.rows());
-    EXPECT_EQ(it->second->_matrix.cols(), kv.second->_matrix.cols());
-    EXPECT_EQ(it->second->_matrix, kv.second->_matrix);
+    const auto *src_group = trx->get_group_members(kv.first);
+    const auto *copy_group = copy->get_group_members(kv.first);
+    ASSERT_NE(src_group, nullptr);
+    ASSERT_NE(copy_group, nullptr);
+    EXPECT_EQ(copy_group->_matrix.rows(), src_group->_matrix.rows());
+    EXPECT_EQ(copy_group->_matrix.cols(), src_group->_matrix.cols());
+    EXPECT_EQ(copy_group->_matrix, src_group->_matrix);
   }
 
   EXPECT_EQ(copy->data_per_group.size(), trx->data_per_group.size());
@@ -243,6 +477,41 @@ TEST(TrxFileTpp, LoadOffsetsMissingSentinel) {
   EXPECT_EQ(trx->streamlines->_offsets(2, 0), 4u);
   EXPECT_EQ(trx->num_streamlines(), 2u);
   EXPECT_EQ(trx->num_vertices(), 4u);
+
+  trx->close();
+  std::error_code ec;
+  fs::remove_all(data_dir, ec);
+}
+
+TEST(TrxFileTpp, MetadataArraysAreUnmappedAfterLoad) {
+  const fs::path data_dir = create_float_trx_dir();
+  auto reader = load_trx_dir<float>(data_dir);
+  auto *trx = reader.get();
+
+  for (const auto &kv : trx->groups) {
+    EXPECT_EQ(kv.second, nullptr);
+    const auto *group = trx->get_group_members(kv.first);
+    ASSERT_NE(group, nullptr);
+    EXPECT_EQ(group->mmap.file_handle(), mio::invalid_handle);
+    EXPECT_FALSE(group->_matrix_owned.empty());
+  }
+  for (const auto &kv : trx->data_per_streamline) {
+    ASSERT_NE(kv.second, nullptr);
+    EXPECT_EQ(kv.second->mmap.file_handle(), mio::invalid_handle);
+    EXPECT_FALSE(kv.second->_matrix_owned.empty());
+  }
+  for (const auto &kv : trx->data_per_vertex) {
+    ASSERT_NE(kv.second, nullptr);
+    EXPECT_NE(kv.second->mmap_pos.file_handle(), mio::invalid_handle);
+    EXPECT_TRUE(kv.second->_data_owned.empty());
+  }
+  for (const auto &group_kv : trx->data_per_group) {
+    for (const auto &field_kv : group_kv.second) {
+      ASSERT_NE(field_kv.second, nullptr);
+      EXPECT_EQ(field_kv.second->mmap.file_handle(), mio::invalid_handle);
+      EXPECT_FALSE(field_kv.second->_matrix_owned.empty());
+    }
+  }
 
   trx->close();
   std::error_code ec;
@@ -500,6 +769,160 @@ TEST(TrxFileTpp, ComputeGroupConnectivityFromSyntheticFileDpsWeighted) {
   std::error_code ec;
   fs::remove_all(trx_path.parent_path(), ec);
 }
+
+TEST(TrxFileTpp, ComputeGroupConnectivityDpsSumRequiresFieldName) {
+  const fs::path trx_path = create_connectivity_fixture_trx();
+  auto reader = trx::TrxReader<float>(trx_path.string());
+  auto *trx = reader.get();
+
+  EXPECT_THROW(static_cast<void>(trx->compute_group_connectivity(ConnectivityMeasure::DpsSum, "")),
+               trx::TrxArgumentError);
+
+  trx->close();
+  std::error_code ec;
+  fs::remove_all(trx_path.parent_path(), ec);
+}
+
+TEST(TrxFileTpp, ComputeGroupConnectivityDpsSumRejectsNonScalarDps) {
+  const fs::path data_dir = create_connectivity_bad_dps_fixture_dir();
+  auto reader = load_trx_dir<float>(data_dir);
+  auto *trx = reader.get();
+  EXPECT_THROW(static_cast<void>(trx->compute_group_connectivity(ConnectivityMeasure::DpsSum, "weights2d")),
+               trx::TrxFormatError);
+
+  trx->close();
+  std::error_code ec;
+  fs::remove_all(data_dir, ec);
+}
+
+TEST(TrxFileTpp, ComputeGroupConnectivityNoGroupsAndNoMemberships) {
+  {
+    const fs::path trx_path = create_connectivity_no_groups_fixture_trx(3);
+    auto reader = trx::TrxReader<float>(trx_path.string());
+    auto *trx = reader.get();
+
+    const auto result = trx->compute_group_connectivity(ConnectivityMeasure::StreamlineCount);
+    EXPECT_TRUE(result.group_names.empty());
+    EXPECT_TRUE(result.streamline_count_upper.empty());
+    EXPECT_TRUE(result.value_upper.empty());
+
+    trx->close();
+    std::error_code ec;
+    fs::remove_all(trx_path.parent_path(), ec);
+  }
+
+  {
+    const fs::path data_dir = create_connectivity_empty_group_fixture_dir();
+    auto reader = load_trx_dir<float>(data_dir);
+    auto *trx = reader.get();
+
+    const auto result = trx->compute_group_connectivity(ConnectivityMeasure::StreamlineCount);
+    ASSERT_EQ(result.group_names.size(), 1u);
+    EXPECT_EQ(result.group_names[0], "Empty");
+    ASSERT_EQ(result.streamline_count_upper.size(), 1u);
+    ASSERT_EQ(result.value_upper.size(), 1u);
+    EXPECT_EQ(result.streamline_count_upper[0], 0u);
+    EXPECT_DOUBLE_EQ(result.value_upper[0], 0.0);
+
+    trx->close();
+    std::error_code ec;
+    fs::remove_all(data_dir, ec);
+  }
+}
+
+TEST(TrxFileTpp, ComputeGroupConnectivityIgnoresOutOfRangeGroupIds) {
+  const fs::path data_dir = create_connectivity_out_of_range_group_fixture_dir();
+  auto reader = load_trx_dir<float>(data_dir);
+  auto *trx = reader.get();
+
+  const auto result = trx->compute_group_connectivity(ConnectivityMeasure::StreamlineCount);
+  ASSERT_EQ(result.group_names.size(), 1u);
+  EXPECT_EQ(result.group_names[0], "A");
+  ASSERT_EQ(result.streamline_count_upper.size(), 1u);
+  ASSERT_EQ(result.value_upper.size(), 1u);
+  // Only ids {0,2} are valid for NB_STREAMLINES=3; id 99 is ignored.
+  EXPECT_EQ(result.streamline_count_upper[0], 2u);
+  EXPECT_DOUBLE_EQ(result.value_upper[0], 2.0);
+
+  trx->close();
+  std::error_code ec;
+  fs::remove_all(data_dir, ec);
+}
+
+TEST(TrxFileTpp, ComputeGroupConnectivityLargeLazyGroupFallbackPath) {
+  constexpr size_t kStreamlines = 100000;
+  constexpr size_t kDuplicateFactor = 5;
+
+  const fs::path data_dir = create_connectivity_large_lazy_group_fixture_dir(kStreamlines, kDuplicateFactor);
+  auto reader = load_trx_dir<float>(data_dir);
+  auto *trx = reader.get();
+
+  auto it = trx->groups.find("All");
+  ASSERT_NE(it, trx->groups.end());
+  ASSERT_EQ(it->second, nullptr) << "Expected lazy group backing before compute.";
+
+  const auto result = trx->compute_group_connectivity(ConnectivityMeasure::StreamlineCount);
+  ASSERT_EQ(result.group_names.size(), 1u);
+  EXPECT_EQ(result.group_names[0], "All");
+  ASSERT_EQ(result.streamline_count_upper.size(), 1u);
+  ASSERT_EQ(result.value_upper.size(), 1u);
+  // Duplicate ids must be de-duplicated per-streamline before pair accumulation.
+  EXPECT_EQ(result.streamline_count_upper[0], kStreamlines);
+  EXPECT_DOUBLE_EQ(result.value_upper[0], static_cast<double>(kStreamlines));
+
+  // compute_group_connectivity should be able to consume lazy group backing directly.
+  EXPECT_EQ(trx->groups["All"], nullptr);
+
+  trx->close();
+  std::error_code ec;
+  fs::remove_all(data_dir, ec);
+}
+
+#if !defined(_WIN32) && !defined(_WIN64)
+TEST(TrxFileTpp, LazyLoadManyGroupsUnderTightFileDescriptorLimit) {
+  const fs::path trx_path = create_many_groups_fixture_trx(400, 32);
+  auto reader = trx::TrxReader<float>(trx_path.string());
+  auto *trx = reader.get();
+  ASSERT_EQ(trx->groups.size(), 400u);
+
+  NoFileLimitRestoreGuard guard;
+  if (getrlimit(RLIMIT_NOFILE, &guard.old_limit) != 0) {
+    GTEST_SKIP() << "getrlimit(RLIMIT_NOFILE) failed: errno=" << errno << " (" << std::strerror(errno) << ")";
+  }
+
+  const rlim_t requested_soft_limit = 64;
+  if (guard.old_limit.rlim_cur <= requested_soft_limit) {
+    GTEST_SKIP() << "Current soft RLIMIT_NOFILE is already tight (" << guard.old_limit.rlim_cur << ")";
+  }
+  if (guard.old_limit.rlim_max < requested_soft_limit) {
+    GTEST_SKIP() << "Hard RLIMIT_NOFILE too low for this test setup: " << guard.old_limit.rlim_max;
+  }
+
+  rlimit tight = guard.old_limit;
+  tight.rlim_cur = requested_soft_limit;
+  if (setrlimit(RLIMIT_NOFILE, &tight) != 0) {
+    GTEST_SKIP() << "setrlimit(RLIMIT_NOFILE) failed: errno=" << errno << " (" << std::strerror(errno) << ")";
+  }
+  guard.active = true;
+
+  for (const auto &kv : trx->groups) {
+    const auto *group = trx->get_group_members(kv.first);
+    ASSERT_NE(group, nullptr);
+    // Regression guard: lazy load should materialize and close each backing file.
+    EXPECT_EQ(group->mmap.file_handle(), mio::invalid_handle);
+    EXPECT_FALSE(group->_matrix_owned.empty());
+  }
+
+  // Also exercise the estimator over many groups in the same tight-fd regime.
+  const auto connectivity = trx->compute_group_connectivity(ConnectivityMeasure::StreamlineCount);
+  EXPECT_EQ(connectivity.group_names.size(), 400u);
+  EXPECT_EQ(connectivity.streamline_count_upper.size(), (400u * 401u) / 2u);
+
+  trx->close();
+  std::error_code ec;
+  fs::remove_all(trx_path.parent_path(), ec);
+}
+#endif
 
 // resize() with default arguments is a no-op when sizes already match.
 TEST(TrxFileTpp, ResizeNoChange) {


### PR DESCRIPTION
I was running into an issue when opening trx files with hundreds of groups. This only loads groups on demand, and makes them not memmapped