### PR TITLE
BUG: Read the extension from the final path component in get_ext

### DIFF
--- a/src/trx.cpp
+++ b/src/trx.cpp
@@ -849,12 +849,17 @@ std::string get_base(const std::string &delimiter, const std::string &str) {
 }
 
 std::string get_ext(const std::string &str) {
+  // Extract the extension from the final path component only. Scanning the
+  // whole path for '.' mistakes a dot in a parent directory (e.g. a
+  // version-numbered build path like ".../foo-5.4/out") for the extension.
+  const std::size_t sep = str.find_last_of("/\\");
+  const std::string name = (sep == std::string::npos) ? str : str.substr(sep + 1);
+
   std::string ext;
   constexpr char kDelimiter = '.';
-
-  const std::size_t pos = str.rfind(kDelimiter);
-  if (pos != std::string::npos && pos + 1 < str.length()) {
-    ext = str.substr(pos + 1);
+  const std::size_t pos = name.rfind(kDelimiter);
+  if (pos != std::string::npos && pos + 1 < name.length()) {
+    ext = name.substr(pos + 1);
   }
   return ext;
 }

--- a/tests/test_trx_io.cpp
+++ b/tests/test_trx_io.cpp
@@ -839,3 +839,21 @@ TEST(TrxFileIo, export_dpv_to_tsf_errors) {
   trx::TrxFile<float> empty;
   EXPECT_THROW(empty.export_dpv_to_tsf("signal", output_path.string(), "1"), trx::TrxFormatError);
 }
+
+// get_ext must read the extension from the final path component only. A '.' in
+// a parent directory (e.g. a version-numbered build path like ".../foo-5.4/")
+// must not be treated as the extension. Regression for "Unsupported extension".
+TEST(TrxFileIo, get_ext_uses_final_path_component) {
+  // Dotted parent directory, file has no extension -> empty (the bug case).
+  EXPECT_EQ(trx::get_ext("/a/build-5.4/out/trx_test"), "");
+  EXPECT_EQ(trx::get_ext("/a/build-5.4/out/trx_test.trx"), "trx");
+  // No path separator: whole string is the name.
+  EXPECT_EQ(trx::get_ext("out.trx"), "trx");
+  EXPECT_EQ(trx::get_ext("trx_test"), "");
+  // dtype-style array filenames (name.dims.dtype) resolve to the dtype, even
+  // under a dotted parent directory.
+  EXPECT_EQ(trx::get_ext("/a/shard.1/positions.3.float32"), "float32");
+  EXPECT_EQ(trx::get_ext("offsets.uint64"), "uint64");
+  // Trailing dot -> empty.
+  EXPECT_EQ(trx::get_ext("/a/b.c/name."), "");
+}


### PR DESCRIPTION
`get_ext()` scans the **entire path** for `.`, so a dot in any parent directory is mistaken for the file extension. For a version-numbered build/output path like `.../build-5.4/…/trx_test` (a file with no extension), `get_ext` returns `"4/…/trx_test"`, which the writer rejects with **"Unsupported extension"**. This fixes it to read the extension from the final path component only.

<details>
<summary>Root cause</summary>

```cpp
// before
const std::size_t pos = str.rfind('.');   // '.' anywhere in the path
```

`rfind('.')` on the full path finds the dot in `build-5.4`, not in the filename:

```
get_ext(".../build-5.4/out/trx_test") = "4/out/trx_test"   -> "Unsupported extension"
get_ext(".../build-main/out/trx_test") = ""                -> ok (no dot in path)
```

The fix restricts the search to the substring after the last `/` or `\`, then takes the part after that component's last `.`.

</details>

<details>
<summary>No change to dtype extraction</summary>

`get_ext` is also used to read the dtype from array element filenames (`positions.3.float32`, `offsets.uint64`). Those carry the dot in the basename, so the returned dtype is unchanged — the fix only differs when the basename has **no** dot but a parent directory does.

</details>

<details>
<summary>Testing</summary>

Adds `TrxFileIo.get_ext_uses_final_path_component`:

```
get_ext("/a/build-5.4/out/trx_test")        == ""          // the bug case
get_ext("/a/build-5.4/out/trx_test.trx")    == "trx"
get_ext("out.trx")                          == "trx"
get_ext("trx_test")                         == ""
get_ext("/a/shard.1/positions.3.float32")   == "float32"    // dtype filename, dotted parent
get_ext("offsets.uint64")                   == "uint64"
get_ext("/a/b.c/name.")                     == ""           // trailing dot
```

Full `ctest` suite passes **185/185** (the dtype callers are exercised by `test_io`).

</details>

Found via an ITK v5-vs-v6 downstream build testbed whose build path contained a dotted directory; the three `ITKTractographyTRX` tests that failed there pass with this change.

<!--
provenance: claude-code session 2026-07-17
branch: hjmjohnson/trx-cpp fix-get-ext-path-basename (11d0c81) off upstream/main 3921412
tested: standalone ctest 185/185 (pixi clang 19); also verified 9/9 ITKTractographyTRX
  module tests on ITK 5.4.6 in a dotted build path (was 6/9 before this fix).
sibling: get_base(delimiter, str) takes an explicit delimiter and is only called
  with "/" (basename) -- correct for its use, left unchanged.
related: ITKTractographyTRX PR tee-ar-ex/ITKTractographyTRX#30 (ITK v5/v6 build-glue
  portability). That PR makes the module BUILD on ITK 5.4; this PR makes its tests PASS
  in dotted build paths. The two are independent and complementary.
-->
